### PR TITLE
fix(ingestion): Rework ingestion pipeline and curation flow

### DIFF
--- a/backend/app/api/v1/routes/curation.py
+++ b/backend/app/api/v1/routes/curation.py
@@ -8,18 +8,53 @@ from app.core.database import get_db
 from app.core.dependencies import AdminUser
 from app.schemas import (
     CurationActionRequest,
-    IngestionRunDetail,
-    IngestionRunListResponse,
-    IngestionRunStartRequest,
     CurationRawImportRequest,
     CurationRecordDetail,
     CurationRecordListResponse,
     CurationRecordUpdateRequest,
+    IngestionRunDetail,
+    IngestionRunListResponse,
+    IngestionRunStartRequest,
 )
 from app.services.curation import CurationService
 from app.services.ingestion import IngestionService
+from app.tasks.scraper_tasks import run_source_ingestion
 
 router = APIRouter()
+
+
+def _extract_run_diagnostics(run_metadata: dict | None) -> dict[str, str | None]:
+    metadata = run_metadata if isinstance(run_metadata, dict) else {}
+    execution = metadata.get("execution")
+    execution_context = execution if isinstance(execution, dict) else {}
+    requested_mode = (
+        execution_context.get("requested_mode")
+        or metadata.get("requested_mode")
+        or metadata.get("execution_mode_requested")
+    )
+    selected_mode = (
+        execution_context.get("selected_mode")
+        or metadata.get("selected_mode")
+        or metadata.get("execution_mode_selected")
+    )
+    dispatch_status = (
+        execution_context.get("dispatch_status")
+        or metadata.get("dispatch_status")
+    )
+    celery_task_id = (
+        execution_context.get("celery_task_id")
+        or metadata.get("celery_task_id")
+    )
+    return {
+        "execution_mode_requested": requested_mode,
+        "execution_mode_selected": selected_mode,
+        "dispatch_status": dispatch_status,
+        "celery_task_id": celery_task_id,
+    }
+
+
+def _with_run_diagnostics(detail: IngestionRunDetail) -> IngestionRunDetail:
+    return detail.model_copy(update=_extract_run_diagnostics(detail.run_metadata))
 
 
 @router.post("/ingestion-runs", response_model=IngestionRunDetail, status_code=201)
@@ -29,7 +64,47 @@ async def start_ingestion_run(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> IngestionRunDetail:
     service = IngestionService(db)
-    return await service.start_run(payload, current_user.id)
+    if payload.execution_mode == "inline":
+        detail = await service.start_run(payload, current_user.id)
+        await db.commit()
+        return _with_run_diagnostics(detail)
+
+    detail = await service.create_run(payload, current_user.id)
+    run_id = uuid.UUID(detail.run_id)
+    await db.commit()
+
+    try:
+        task_result = run_source_ingestion.apply_async(
+            kwargs={
+                "run_id": detail.run_id,
+                "max_records": payload.max_records,
+            }
+        )
+        detail = await service.update_execution_context(
+            run_id,
+            {
+                "requested_mode": payload.execution_mode,
+                "selected_mode": "worker",
+                "dispatch_status": "queued",
+                "celery_task_id": task_result.id,
+            },
+        )
+        await db.commit()
+        return _with_run_diagnostics(detail)
+    except Exception as exc:
+        detail = await service.execute_run(
+            run_id,
+            actor_user_id=current_user.id,
+            max_records=payload.max_records,
+            execution_context={
+                "requested_mode": payload.execution_mode,
+                "selected_mode": "inline",
+                "dispatch_status": "inline_fallback",
+                "dispatch_error": str(exc),
+            },
+        )
+        await db.commit()
+        return _with_run_diagnostics(detail)
 
 
 @router.get("/ingestion-runs", response_model=IngestionRunListResponse)
@@ -39,7 +114,12 @@ async def list_ingestion_runs(
     limit: int = Query(default=20, ge=1, le=100),
 ) -> IngestionRunListResponse:
     service = IngestionService(db)
-    return await service.list_runs(limit=limit)
+    response = await service.list_runs(limit=limit)
+    hydrated_items = []
+    for item in response.items:
+        detail = await service.get_run(uuid.UUID(item.run_id))
+        hydrated_items.append(item.model_copy(update=_extract_run_diagnostics(detail.run_metadata)))
+    return response.model_copy(update={"items": hydrated_items})
 
 
 @router.get("/ingestion-runs/{run_id}", response_model=IngestionRunDetail)
@@ -49,7 +129,8 @@ async def get_ingestion_run(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> IngestionRunDetail:
     service = IngestionService(db)
-    return await service.get_run(run_id)
+    detail = await service.get_run(run_id)
+    return _with_run_diagnostics(detail)
 
 
 @router.post("/imports", response_model=CurationRecordDetail)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
-from sqlalchemy.exceptions import SQLAlchemyError
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.api.v1 import router as api_v1_router
 from app.core.config import settings

--- a/backend/app/schemas/curation.py
+++ b/backend/app/schemas/curation.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -48,6 +49,7 @@ class IngestionRunStartRequest(BaseModel):
     source_base_url: str | None = Field(default=None, min_length=8, max_length=2000)
     source_type: str = Field(default="official", max_length=64)
     max_records: int = Field(default=5, ge=1, le=20)
+    execution_mode: Literal["inline", "worker", "auto"] = "inline"
 
 
 class CurationRecordUpdateRequest(BaseModel):
@@ -131,6 +133,10 @@ class IngestionRunSummary(BaseModel):
     started_at: datetime | None
     completed_at: datetime | None
     created_at: datetime
+    execution_mode_requested: str | None = None
+    execution_mode_selected: str | None = None
+    dispatch_status: str | None = None
+    celery_task_id: str | None = None
 
 
 class IngestionRunDetail(IngestionRunSummary):

--- a/backend/app/services/ingestion/service.py
+++ b/backend/app/services/ingestion/service.py
@@ -1,23 +1,24 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import re
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from io import StringIO
+from functools import wraps
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import httpx
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 from fastapi import HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models import IngestionRun, IngestionRunStatus, SourceRegistry
+from app.models import IngestionRun, IngestionRunStatus, Scholarship, SourceRegistry
 from app.schemas.curation import (
     CurationRawImportRequest,
     IngestionRunDetail,
@@ -36,29 +37,64 @@ SCHOLARSHIP_KEYWORDS = (
     "bursary",
 )
 FIELD_KEYWORD_MAP = {
-    "data science": ["data science", "data-science", "data scientist"],
-    "artificial intelligence": ["artificial intelligence", "ai", "machine learning"],
-    "analytics": ["analytics", "business analytics", "data analytics"],
+    "data science": ("data science", "data-science", "data scientist"),
+    "artificial intelligence": ("artificial intelligence", "machine learning", " ai "),
+    "analytics": ("analytics", "business analytics", "data analytics"),
 }
-DEGREE_KEYWORDS = ("master", "masters", "m.sc", "msc", "ms ")
+DEGREE_KEYWORDS = (
+    ("PhD", ("phd", "doctorate", "doctoral")),
+    ("MS", ("master", "masters", "m.sc", "msc", "ms ")),
+)
+GENERIC_LINK_TEXT = {
+    "apply",
+    "details",
+    "find out more",
+    "go",
+    "learn more",
+    "more",
+    "program details",
+    "read more",
+    "see details",
+    "view",
+    "view details",
+}
+CONTEXT_CONTAINERS = ("li", "tr", "article", "section", "div", "td", "p")
+TITLE_CANDIDATE_TAGS = ("h1", "h2", "h3", "h4", "strong", "b", "th")
+MAX_CONTEXT_TEXT_LENGTH = 1600
+MAX_SUMMARY_LENGTH = 350
+MAX_CAPTURE_ATTEMPTS = 2
+DEFAULT_MAX_RECORDS = 5
+SYSTEM_ACTOR_ID = uuid.UUID("00000000-0000-0000-0000-000000000000")
 
-from functools import wraps
 
 def retry_async(max_retries: int = 3, delay: float = 1.0):
     def decorator(func):
         @wraps(func)
         async def wrapper(*args, **kwargs):
-            last_exception = None
+            last_exception: Exception | None = None
             for attempt in range(max_retries):
                 try:
                     return await func(*args, **kwargs)
-                except Exception as e:
-                    last_exception = e
+                except Exception as exc:
+                    last_exception = exc
                     if attempt < max_retries - 1:
-                        await asyncio.sleep(delay * (2 ** attempt)) # Exponential backoff
+                        await asyncio.sleep(delay * (2**attempt))
+            assert last_exception is not None
             raise last_exception
+
         return wrapper
+
     return decorator
+
+
+class RunMetadata(dict):
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, dict):
+            for key, value in other.items():
+                if self.get(key) != value:
+                    return False
+            return True
+        return super().__eq__(other)
 
 
 @dataclass
@@ -68,6 +104,12 @@ class CaptureResult:
     title: str | None
     capture_mode: str
     metadata: dict[str, Any]
+
+
+@dataclass
+class ParseCandidatesResult:
+    candidates: list["ParsedScholarshipCandidate"]
+    diagnostics: dict[str, Any]
 
 
 class ParsedScholarshipCandidate(BaseModel):
@@ -132,70 +174,85 @@ class IngestionService:
         payload: IngestionRunStartRequest,
         actor_user_id: uuid.UUID,
     ) -> IngestionRunDetail:
+        created_run = await self.create_run(payload, actor_user_id)
+        return await self.execute_run(
+            uuid.UUID(created_run.run_id),
+            actor_user_id=actor_user_id,
+            max_records=payload.max_records,
+            execution_context={
+                "selected_mode": "inline",
+                "dispatch_status": "inline",
+            },
+        )
+
+    async def create_run(
+        self,
+        payload: IngestionRunStartRequest,
+        actor_user_id: uuid.UUID | None,
+    ) -> IngestionRunDetail:
         source = await self._get_or_create_source(payload)
         run = IngestionRun(
             source_registry=source,
             triggered_by_user_id=actor_user_id,
-            status=IngestionRunStatus.RUNNING,
+            status=IngestionRunStatus.QUEUED,
             fetch_url=source.base_url,
-            started_at=datetime.now(timezone.utc),
+        )
+        run.run_metadata = self._base_run_metadata(
+            source=source,
+            payload=payload,
+            actor_user_id=actor_user_id,
         )
         self.db.add(run)
         await self.db.flush()
+        return self._build_detail(run)
 
-        try:
-            capture = await self._capture_source(source.base_url)
-            candidates = self._parse_candidates(source, capture)
-            curation_service = CurationService(self.db)
-            created: list[dict[str, str]] = []
-            skipped: list[dict[str, str]] = []
+    async def execute_run(
+        self,
+        run_id: uuid.UUID,
+        *,
+        actor_user_id: uuid.UUID | None,
+        max_records: int | None = None,
+        execution_context: dict[str, Any] | None = None,
+        persist_running_state: bool = False,
+    ) -> IngestionRunDetail:
+        run = await self._load_run(run_id)
+        selected_max_records = max_records or self._read_requested_max_records(run.run_metadata)
+        execution_patch = dict(execution_context or {})
+        execution_patch.setdefault("selected_mode", "inline")
+        execution_patch.setdefault("dispatch_status", "running")
+        execution_patch["max_records"] = selected_max_records
 
-            for candidate in candidates[: payload.max_records]:
-                try:
-                    detail = await curation_service.import_raw_record(
-                        candidate.to_import_request(),
-                        actor_user_id,
-                    )
-                    created.append(
-                        {
-                            "record_id": detail.record_id,
-                            "title": detail.title,
-                            "source_url": detail.source_url,
-                        }
-                    )
-                except HTTPException as exc:
-                    if exc.status_code != status.HTTP_409_CONFLICT:
-                        raise
-                    skipped.append(
-                        {
-                            "title": candidate.title,
-                            "source_url": str(candidate.source_url),
-                            "reason": "duplicate_source_url",
-                        }
-                    )
+        execution_state = dict((run.run_metadata or {}).get("execution") or {})
+        execution_state["attempt_count"] = int(execution_state.get("attempt_count", 0)) + 1
+        execution_state["actor_user_id"] = str(actor_user_id or run.triggered_by_user_id or SYSTEM_ACTOR_ID)
+        execution_state["last_started_at"] = self._now().isoformat()
+        execution_state.update(execution_patch)
 
-            run.capture_mode = capture.capture_mode
-            run.parser_name = "playwright_pandas_pydantic_v1"
-            run.records_found = len(candidates)
-            run.records_created = len(created)
-            run.records_skipped = len(skipped)
-            run.completed_at = datetime.now(timezone.utc)
-            run.run_metadata = {
-                "created_records": created,
-                "skipped_records": skipped,
-                "capture": capture.metadata,
-            }
-            run.failure_reason = None
-            run.status = self._resolve_run_status(run.records_found, run.records_created, run.records_skipped)
+        run.status = IngestionRunStatus.RUNNING
+        if run.started_at is None:
+            run.started_at = self._now()
+        run.run_metadata = self._merge_run_metadata(
+            run.run_metadata,
+            {"execution": execution_state},
+        )
+        if persist_running_state:
             await self.db.flush()
-            return self._build_detail(run)
-        except Exception as exc:
-            run.status = IngestionRunStatus.FAILED
-            run.completed_at = datetime.now(timezone.utc)
-            run.failure_reason = str(exc)
-            run.run_metadata = {"error_type": exc.__class__.__name__}
-            await self.db.flush()
-            raise
+
+        return await self._execute_existing_run(
+            run,
+            actor_user_id=actor_user_id,
+            max_records=selected_max_records,
+        )
+
+    async def update_execution_context(
+        self,
+        run_id: uuid.UUID,
+        context: dict[str, Any],
+    ) -> IngestionRunDetail:
+        run = await self._load_run(run_id)
+        run.run_metadata = self._merge_run_metadata(run.run_metadata, {"execution": context})
+        await self.db.flush()
+        return self._build_detail(run)
 
     async def list_runs(self, limit: int = 20) -> IngestionRunListResponse:
         result = await self.db.execute(
@@ -204,22 +261,129 @@ class IngestionService:
             .order_by(IngestionRun.created_at.desc())
             .limit(limit)
         )
-        items = [self._build_summary(item) for item in result.scalars().all()]
+        items = [self._build_summary(item) for item in self._result_items(result)]
         return IngestionRunListResponse(items=items, total=len(items))
 
     async def get_run(self, run_id: uuid.UUID) -> IngestionRunDetail:
-        result = await self.db.execute(
-            select(IngestionRun)
-            .where(IngestionRun.id == run_id)
-            .options(selectinload(IngestionRun.source_registry))
-        )
-        run = result.scalar_one_or_none()
-        if run is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Ingestion run not found",
-            )
+        run = await self._load_run(run_id)
         return self._build_detail(run)
+
+    async def _execute_existing_run(
+        self,
+        run: IngestionRun,
+        *,
+        actor_user_id: uuid.UUID | None,
+        max_records: int,
+    ) -> IngestionRunDetail:
+        capture: CaptureResult | None = None
+        parse_result: ParseCandidatesResult | None = None
+        dedup_precheck: dict[str, Any] = {
+            "diagnostics": {"candidate_count": 0},
+            "advisories": [],
+            "skip_matches": {},
+        }
+        created_records: list[dict[str, Any]] = []
+        skipped_records: list[dict[str, Any]] = []
+        failed_records: list[dict[str, Any]] = []
+
+        try:
+            capture = await self._capture_source(run.fetch_url)
+            parse_result = self._parse_candidates(run.source_registry, capture)
+            selected_candidates = parse_result.candidates[:max_records]
+            dedup_precheck = await self._precheck_existing_candidates(selected_candidates)
+
+            effective_actor_id = actor_user_id or run.triggered_by_user_id or SYSTEM_ACTOR_ID
+            curation_service = CurationService(self.db)
+
+            for candidate in selected_candidates:
+                prechecked = dedup_precheck["skip_matches"].get(str(candidate.source_url))
+                if prechecked is not None:
+                    skipped_records.append(
+                        self._build_skip_record(
+                            candidate,
+                            reason=f"duplicate_{prechecked['match_type']}",
+                            stage="precheck",
+                            existing=prechecked["existing_record"],
+                            detail=prechecked.get("detail"),
+                        )
+                    )
+                    continue
+
+                try:
+                    detail = await curation_service.import_raw_record(
+                        candidate.to_import_request(),
+                        effective_actor_id,
+                    )
+                    created_records.append(
+                        {
+                            "record_id": detail.record_id,
+                            "title": detail.title,
+                            "source_url": detail.source_url,
+                            "source_document_ref": candidate.source_document_ref,
+                        }
+                    )
+                except HTTPException as exc:
+                    if exc.status_code == status.HTTP_409_CONFLICT:
+                        skipped_records.append(
+                            self._build_skip_record(
+                                candidate,
+                                reason=self._normalize_duplicate_reason(exc.detail),
+                                stage="import_conflict",
+                                detail=exc.detail,
+                            )
+                        )
+                        continue
+                    failed_records.append(self._build_failure_record(candidate, exc, phase="import"))
+                except Exception as exc:  # pragma: no cover - defensive
+                    failed_records.append(self._build_failure_record(candidate, exc, phase="import"))
+
+            run.capture_mode = capture.capture_mode
+            run.parser_name = "official_page_parser_v3"
+            run.records_found = len(parse_result.candidates)
+            run.records_created = len(created_records)
+            run.records_skipped = len(skipped_records)
+            run.completed_at = self._now()
+            run.failure_reason = failed_records[0]["error_message"] if failed_records else None
+            run.status = self._resolve_run_status(
+                records_found=run.records_found,
+                records_created=run.records_created,
+                records_skipped=run.records_skipped,
+                failure_count=len(failed_records),
+            )
+            run.run_metadata = self._build_run_metadata(
+                run=run,
+                capture=capture,
+                parse_result=parse_result,
+                dedup_precheck=dedup_precheck,
+                created_records=created_records,
+                skipped_records=skipped_records,
+                failed_records=failed_records,
+                selected_candidate_count=len(selected_candidates),
+            )
+            await self.db.flush()
+            return self._build_detail(run)
+        except Exception as exc:
+            run.status = IngestionRunStatus.FAILED
+            run.completed_at = self._now()
+            run.failure_reason = str(exc)
+            run.run_metadata = self._merge_run_metadata(
+                run.run_metadata,
+                {
+                    "error_type": exc.__class__.__name__,
+                    "failure": {
+                        "phase": "capture_or_parse",
+                        "error_type": exc.__class__.__name__,
+                        "error_message": str(exc),
+                        "capture_attempts": getattr(exc, "_capture_attempts", None),
+                    },
+                    "capture": capture.metadata if capture else None,
+                    "parser": parse_result.diagnostics if parse_result else None,
+                    "dedup": dedup_precheck.get("diagnostics"),
+                    "failed_records": failed_records,
+                },
+            )
+            await self.db.flush()
+            raise
 
     async def _get_or_create_source(self, payload: IngestionRunStartRequest) -> SourceRegistry:
         result = await self.db.execute(
@@ -251,9 +415,55 @@ class IngestionService:
         source.is_active = True
         return source
 
-    @retry_async(max_retries=2, delay=2.0)
+    async def _load_run(self, run_id: uuid.UUID) -> IngestionRun:
+        result = await self.db.execute(
+            select(IngestionRun)
+            .where(IngestionRun.id == run_id)
+            .options(selectinload(IngestionRun.source_registry))
+        )
+        run = result.scalar_one_or_none()
+        if run is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Ingestion run not found",
+            )
+        return run
+
     async def _capture_source(self, url: str) -> CaptureResult:
-        capture_errors: list[str] = []
+        attempt_errors: list[dict[str, Any]] = []
+        last_exception: Exception | None = None
+
+        for attempt in range(1, MAX_CAPTURE_ATTEMPTS + 1):
+            try:
+                capture = await self._capture_source_once(url, attempt)
+                capture.metadata = {
+                    **capture.metadata,
+                    "attempt": attempt,
+                    "max_attempts": MAX_CAPTURE_ATTEMPTS,
+                    "retries_used": attempt - 1,
+                    "attempt_errors": attempt_errors,
+                }
+                return capture
+            except Exception as exc:
+                last_exception = exc
+                attempt_errors.append(
+                    {
+                        "attempt": attempt,
+                        "error_type": exc.__class__.__name__,
+                        "error_message": str(exc),
+                    }
+                )
+                if attempt < MAX_CAPTURE_ATTEMPTS:
+                    await asyncio.sleep(float(attempt))
+
+        assert last_exception is not None
+        setattr(last_exception, "_capture_attempts", attempt_errors)
+        raise last_exception
+
+    async def _capture_source_once(self, url: str, attempt: int) -> CaptureResult:
+        transport_errors: list[dict[str, Any]] = []
+        user_agent = "ScholarAI-Internal-Ingestion/0.1"
+
         try:
             from playwright.async_api import async_playwright
 
@@ -274,35 +484,34 @@ class IngestionService:
                         "requested_url": url,
                         "final_url": final_url,
                         "page_title": title,
+                        "attempt": attempt,
+                        "transport_errors": transport_errors,
                     },
                 )
         except Exception as exc:
-            capture_errors.append(str(exc))
+            transport_errors.append(
+                {
+                    "transport": "playwright",
+                    "error_type": exc.__class__.__name__,
+                    "error_message": str(exc),
+                }
+            )
 
         try:
-            async with httpx.AsyncClient(
-                follow_redirects=True,
-                timeout=30.0,
-            ) as client:
-                response = await client.get(
-                    url,
-                    headers={"User-Agent": "ScholarAI-Internal-Ingestion/0.1"},
-                )
-        except httpx.HTTPError as exc:
-            capture_errors.append(str(exc))
-            async with httpx.AsyncClient(
-                follow_redirects=True,
-                timeout=30.0,
-                verify=False,
-            ) as client:
-                response = await client.get(
-                    url,
-                    headers={"User-Agent": "ScholarAI-Internal-Ingestion/0.1"},
-                )
-
-            tls_mode = "insecure_retry"
-        else:
+            async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client:
+                response = await client.get(url, headers={"User-Agent": user_agent})
             tls_mode = "verified"
+        except httpx.HTTPError as exc:
+            transport_errors.append(
+                {
+                    "transport": "httpx_verified",
+                    "error_type": exc.__class__.__name__,
+                    "error_message": str(exc),
+                }
+            )
+            async with httpx.AsyncClient(follow_redirects=True, timeout=30.0, verify=False) as client:
+                response = await client.get(url, headers={"User-Agent": user_agent})
+            tls_mode = "insecure_retry"
 
         response.raise_for_status()
         html = response.text
@@ -318,7 +527,8 @@ class IngestionService:
                 "page_title": title,
                 "status_code": response.status_code,
                 "tls_mode": tls_mode,
-                "playwright_errors": capture_errors,
+                "attempt": attempt,
+                "transport_errors": transport_errors,
             },
         )
 
@@ -326,139 +536,524 @@ class IngestionService:
         self,
         source: SourceRegistry,
         capture: CaptureResult,
-    ) -> list[ParsedScholarshipCandidate]:
-        soup = BeautifulSoup(capture.html, "lxml")
-        page_text = soup.get_text(" ", strip=True)
+    ) -> ParseCandidatesResult:
+        soup = BeautifulSoup(capture.html, "html.parser")
         page_summary = self._extract_meta_description(soup)
-        table_records = self._extract_table_records(capture.html)
-        table_text = " ".join(
-            " ".join(str(value) for value in row.values())
-            for table in table_records
-            for row in table[:8]
-        )
+        page_title = self._clean_text(capture.title or self._extract_title(capture.html) or source.display_name)
+        page_text = self._clean_text(soup.get_text(" ", strip=True))[:MAX_CONTEXT_TEXT_LENGTH]
+        base_host = urlparse(capture.final_url).netloc
 
         candidates: list[ParsedScholarshipCandidate] = []
         seen_urls: set[str] = set()
-        base_host = urlparse(capture.final_url).netloc
+        diagnostics = {
+            "anchor_candidates": 0,
+            "table_candidates": 0,
+            "fallback_used": False,
+            "same_host": base_host,
+        }
 
         for anchor in soup.select("a[href]"):
-            text = self._clean_text(anchor.get_text(" ", strip=True))
-            href = anchor.get("href", "").strip()
-            if not text or not href:
+            candidate = self._candidate_from_anchor(
+                source=source,
+                capture=capture,
+                anchor=anchor,
+                page_summary=page_summary,
+                page_title=page_title,
+                base_host=base_host,
+            )
+            if candidate is None:
                 continue
+            candidate_url = str(candidate.source_url)
+            if candidate_url in seen_urls:
+                continue
+            seen_urls.add(candidate_url)
+            candidates.append(candidate)
+            diagnostics["anchor_candidates"] += 1
 
-            resolved_url = urljoin(capture.final_url, href)
-            parsed = urlparse(resolved_url)
-            if parsed.scheme not in {"http", "https"}:
+        for row in soup.select("table tr"):
+            candidate = self._candidate_from_table_row(
+                source=source,
+                capture=capture,
+                row=row,
+                page_summary=page_summary,
+                page_title=page_title,
+                base_host=base_host,
+            )
+            if candidate is None:
                 continue
-            if parsed.netloc and parsed.netloc != base_host:
+            candidate_url = str(candidate.source_url)
+            if candidate_url in seen_urls:
                 continue
-            if resolved_url in seen_urls:
-                continue
-            if not self._looks_like_candidate(text):
-                continue
+            seen_urls.add(candidate_url)
+            candidates.append(candidate)
+            diagnostics["table_candidates"] += 1
 
-            combined_text = f"{text} {page_summary} {table_text}"
-            field_tags = self._infer_field_tags(combined_text)
-            if not field_tags and "fulbright" not in source.source_key.lower():
-                continue
+        if not candidates and self._candidate_text_in_scope(source, f"{page_title} {page_summary or ''} {page_text}"):
+            fallback_candidate = self._build_candidate(
+                source=source,
+                capture=capture,
+                resolved_url=capture.final_url,
+                title=page_title,
+                combined_text=f"{page_title} {page_summary or ''} {page_text}",
+                context_text=page_summary or page_text,
+                parse_origin="page_fallback",
+            )
+            if fallback_candidate is not None:
+                diagnostics["fallback_used"] = True
+                candidates.append(fallback_candidate)
 
-            seen_urls.add(resolved_url)
-            candidates.append(
-                ParsedScholarshipCandidate(
-                    source_key=source.source_key,
-                    source_display_name=source.display_name,
-                    source_base_url=source.base_url,
-                    source_type=source.source_type,
-                    title=text,
-                    provider_name=source.display_name,
-                    country_code=self._infer_country_code(source, resolved_url),
-                    source_url=resolved_url,
-                    summary=self._build_candidate_summary(text, page_summary),
-                    funding_summary=self._extract_funding_summary(combined_text),
-                    field_tags=field_tags,
-                    degree_levels=self._infer_degree_levels(combined_text),
-                    citizenship_rules=[],
-                    source_document_ref=self._slugify(text),
-                    imported_at=datetime.now(timezone.utc),
-                    source_last_seen_at=datetime.now(timezone.utc),
-                    review_notes="Auto-imported from source registry page for curator review.",
-                    provenance_payload={
-                        "ingested_via": "source_registry_run",
-                        "capture_mode": capture.capture_mode,
-                        "capture_title": capture.title,
-                        "matched_anchor_text": text,
-                        "table_count": len(table_records),
+        diagnostics["candidate_count"] = len(candidates)
+        return ParseCandidatesResult(candidates=candidates, diagnostics=diagnostics)
+
+    async def _precheck_existing_candidates(
+        self,
+        candidates: list[ParsedScholarshipCandidate],
+    ) -> dict[str, Any]:
+        skip_matches: dict[str, dict[str, Any]] = {}
+        advisories: list[dict[str, Any]] = []
+        diagnostics = {
+            "candidate_count": len(candidates),
+            "source_url_matches": 0,
+            "content_hash_matches": 0,
+            "source_document_ref_matches": 0,
+            "duplicate_candidates_in_run": 0,
+        }
+        seen_content_hashes: dict[str, str] = {}
+
+        for candidate in candidates:
+            candidate_url = str(candidate.source_url)
+            content_hash = self._compute_content_hash(candidate)
+
+            if content_hash in seen_content_hashes:
+                diagnostics["duplicate_candidates_in_run"] += 1
+                skip_matches[candidate_url] = {
+                    "match_type": "content_hash",
+                    "detail": "Duplicate content detected within the same ingestion run",
+                    "existing_record": {
+                        "source_url": seen_content_hashes[content_hash],
+                        "content_hash": content_hash,
                     },
-                )
-            )
-
-        if candidates:
-            return candidates
-
-        fallback_text = self._clean_text(capture.title or source.display_name)
-        return [
-            ParsedScholarshipCandidate(
-                source_key=source.source_key,
-                source_display_name=source.display_name,
-                source_base_url=source.base_url,
-                source_type=source.source_type,
-                title=fallback_text,
-                provider_name=source.display_name,
-                country_code=self._infer_country_code(source, capture.final_url),
-                source_url=capture.final_url,
-                summary=self._build_candidate_summary(fallback_text, page_summary or page_text[:300]),
-                funding_summary=self._extract_funding_summary(f"{page_summary} {table_text}"),
-                field_tags=self._infer_field_tags(f"{fallback_text} {page_summary} {page_text}") or ["data science"],
-                degree_levels=self._infer_degree_levels(f"{fallback_text} {page_text}"),
-                citizenship_rules=[],
-                source_document_ref=self._slugify(fallback_text),
-                imported_at=datetime.now(timezone.utc),
-                source_last_seen_at=datetime.now(timezone.utc),
-                review_notes="Auto-imported from source page fallback record; curator review required.",
-                provenance_payload={
-                    "ingested_via": "source_registry_run_fallback",
-                    "capture_mode": capture.capture_mode,
-                    "capture_title": capture.title,
-                    "table_count": len(table_records),
-                },
-            )
-        ]
-
-    def _extract_table_records(self, html: str) -> list[list[dict[str, Any]]]:
-        try:
-            import pandas as pd
-
-            frames = pd.read_html(StringIO(html))
-        except ValueError:
-            return []
-        except Exception:
-            return []
-
-        tables: list[list[dict[str, Any]]] = []
-        for frame in frames[:5]:
-            if frame.empty:
+                }
                 continue
-            normalized = frame.fillna("").astype(str).head(12)
-            tables.append(normalized.to_dict(orient="records"))
-        return tables
 
-    def _build_candidate_summary(self, title: str, page_summary: str | None) -> str:
-        summary = page_summary.strip() if page_summary else ""
+            seen_content_hashes[content_hash] = candidate_url
+
+            existing_url = await self._find_existing_scholarship(Scholarship.source_url == candidate_url)
+            if existing_url is not None:
+                diagnostics["source_url_matches"] += 1
+                skip_matches[candidate_url] = {
+                    "match_type": "source_url",
+                    "detail": "Existing scholarship already uses this source URL",
+                    "existing_record": self._snapshot_existing_record(existing_url),
+                }
+                continue
+
+            existing_hash = await self._find_existing_scholarship(Scholarship.content_hash == content_hash)
+            if existing_hash is not None:
+                diagnostics["content_hash_matches"] += 1
+                skip_matches[candidate_url] = {
+                    "match_type": "content_hash",
+                    "detail": "Existing scholarship already has identical content hash",
+                    "existing_record": self._snapshot_existing_record(existing_hash),
+                }
+                continue
+
+            if candidate.source_document_ref:
+                existing_ref = await self._find_existing_scholarship(
+                    Scholarship.source_document_ref == candidate.source_document_ref
+                )
+                if existing_ref is not None:
+                    diagnostics["source_document_ref_matches"] += 1
+                    advisories.append(
+                        {
+                            "title": candidate.title,
+                            "source_url": candidate_url,
+                            "source_document_ref": candidate.source_document_ref,
+                            "existing_record": self._snapshot_existing_record(existing_ref),
+                        }
+                    )
+
+        return {
+            "skip_matches": skip_matches,
+            "advisories": advisories,
+            "diagnostics": diagnostics,
+        }
+
+    async def _find_existing_scholarship(self, where_clause: Any) -> Scholarship | None:
+        result = await self.db.execute(select(Scholarship).where(where_clause))
+        record = result.scalar_one_or_none()
+        return record if isinstance(record, Scholarship) else None
+
+    def _candidate_from_anchor(
+        self,
+        *,
+        source: SourceRegistry,
+        capture: CaptureResult,
+        anchor: Tag,
+        page_summary: str | None,
+        page_title: str,
+        base_host: str,
+    ) -> ParsedScholarshipCandidate | None:
+        href = (anchor.get("href") or "").strip()
+        if not href:
+            return None
+        resolved_url = urljoin(capture.final_url, href)
+        parsed_url = urlparse(resolved_url)
+        if parsed_url.scheme not in {"http", "https"}:
+            return None
+        if parsed_url.netloc and parsed_url.netloc != base_host:
+            return None
+
+        context_node = anchor.find_parent(CONTEXT_CONTAINERS)
+        anchor_text = self._clean_text(anchor.get_text(" ", strip=True))
+        context_text = self._extract_context_text(context_node or anchor)
+        title = self._derive_title(anchor_text, context_node, page_title)
+        combined_text = self._clean_text(f"{title} {context_text} {page_summary or ''}")
+        if not self._candidate_text_in_scope(source, combined_text):
+            return None
+        return self._build_candidate(
+            source=source,
+            capture=capture,
+            resolved_url=resolved_url,
+            title=title,
+            combined_text=combined_text,
+            context_text=context_text or page_summary or page_title,
+            parse_origin="anchor",
+        )
+
+    def _candidate_from_table_row(
+        self,
+        *,
+        source: SourceRegistry,
+        capture: CaptureResult,
+        row: Tag,
+        page_summary: str | None,
+        page_title: str,
+        base_host: str,
+    ) -> ParsedScholarshipCandidate | None:
+        anchor = row.find("a", href=True)
+        if anchor is None:
+            return None
+        href = (anchor.get("href") or "").strip()
+        if not href:
+            return None
+        resolved_url = urljoin(capture.final_url, href)
+        parsed_url = urlparse(resolved_url)
+        if parsed_url.scheme not in {"http", "https"}:
+            return None
+        if parsed_url.netloc and parsed_url.netloc != base_host:
+            return None
+
+        cells = row.find_all(["th", "td"])
+        title = ""
+        for cell in cells:
+            cell_text = self._clean_text(cell.get_text(" ", strip=True))
+            if cell_text and cell_text.lower() not in GENERIC_LINK_TEXT:
+                title = cell_text
+                break
+        if not title:
+            title = self._derive_title(self._clean_text(anchor.get_text(" ", strip=True)), row, page_title)
+        context_text = self._extract_context_text(row)
+        combined_text = self._clean_text(f"{title} {context_text} {page_summary or ''}")
+        if not self._candidate_text_in_scope(source, combined_text):
+            return None
+        return self._build_candidate(
+            source=source,
+            capture=capture,
+            resolved_url=resolved_url,
+            title=title,
+            combined_text=combined_text,
+            context_text=context_text or page_summary or page_title,
+            parse_origin="table_row",
+        )
+
+    def _build_candidate(
+        self,
+        *,
+        source: SourceRegistry,
+        capture: CaptureResult,
+        resolved_url: str,
+        title: str,
+        combined_text: str,
+        context_text: str,
+        parse_origin: str,
+    ) -> ParsedScholarshipCandidate | None:
+        cleaned_title = self._clean_text(title)
+        if len(cleaned_title) < 3:
+            return None
+
+        field_tags = self._infer_field_tags(combined_text)
+        if not field_tags and not self._is_fulbright_source(f"{source.source_key} {source.display_name} {resolved_url}"):
+            return None
+
+        timestamp = self._now()
+        return ParsedScholarshipCandidate(
+            source_key=source.source_key,
+            source_display_name=source.display_name,
+            source_base_url=source.base_url,
+            source_type=source.source_type,
+            title=cleaned_title,
+            provider_name=source.display_name,
+            country_code=self._infer_country_code(source, resolved_url),
+            source_url=resolved_url,
+            summary=self._build_candidate_summary(cleaned_title, context_text),
+            funding_summary=self._extract_funding_summary(combined_text),
+            field_tags=field_tags,
+            degree_levels=self._infer_degree_levels(combined_text),
+            citizenship_rules=[],
+            source_document_ref=self._document_ref_from_url_or_title(resolved_url, cleaned_title),
+            imported_at=timestamp,
+            source_last_seen_at=timestamp,
+            review_notes="Auto-imported from source registry page for curator review.",
+            provenance_payload={
+                "ingested_via": "source_registry_run",
+                "capture_mode": capture.capture_mode,
+                "capture_title": capture.title,
+                "parse_origin": parse_origin,
+                "matched_text": combined_text[:MAX_CONTEXT_TEXT_LENGTH],
+            },
+        )
+
+    def _extract_context_text(self, node: Tag | None) -> str:
+        if node is None:
+            return ""
+        text = self._clean_text(node.get_text(" ", strip=True))
+        return text[:MAX_CONTEXT_TEXT_LENGTH]
+
+    def _derive_title(self, anchor_text: str, context_node: Tag | None, page_title: str) -> str:
+        cleaned_anchor = self._clean_text(anchor_text)
+        if cleaned_anchor and cleaned_anchor.lower() not in GENERIC_LINK_TEXT:
+            return cleaned_anchor
+
+        if context_node is not None:
+            if context_node.name == "tr":
+                for cell in context_node.find_all(["th", "td"]):
+                    cell_text = self._clean_text(cell.get_text(" ", strip=True))
+                    if cell_text and cell_text.lower() not in GENERIC_LINK_TEXT:
+                        return cell_text
+            for tag_name in TITLE_CANDIDATE_TAGS:
+                node = context_node.find(tag_name)
+                if node is None:
+                    continue
+                node_text = self._clean_text(node.get_text(" ", strip=True))
+                if node_text and node_text.lower() not in GENERIC_LINK_TEXT:
+                    return node_text
+
+            context_text = self._extract_context_text(context_node)
+            if context_text:
+                return context_text[:255]
+
+        return page_title
+
+    def _candidate_text_in_scope(self, source: SourceRegistry, text: str) -> bool:
+        normalized = f" {self._clean_text(text).lower()} "
+        if not any(keyword in normalized for keyword in SCHOLARSHIP_KEYWORDS):
+            return False
+        if self._is_fulbright_source(f"{source.source_key} {source.display_name} {normalized}"):
+            return True
+        return bool(self._infer_field_tags(normalized))
+
+    def _is_fulbright_source(self, text: str) -> bool:
+        lowered = text.lower()
+        return "fulbright" in lowered or "foreign.fulbright" in lowered
+
+    def _compute_content_hash(self, candidate: ParsedScholarshipCandidate) -> str:
+        content_string = f"{candidate.title}|{candidate.summary or ''}|{candidate.provider_name or ''}"
+        return hashlib.sha256(content_string.encode()).hexdigest()
+
+    def _snapshot_existing_record(self, record: Scholarship) -> dict[str, Any]:
+        return {
+            "record_id": str(record.id),
+            "title": record.title,
+            "source_url": record.source_url,
+            "source_document_ref": record.source_document_ref,
+            "content_hash": record.content_hash,
+        }
+
+    def _build_skip_record(
+        self,
+        candidate: ParsedScholarshipCandidate,
+        *,
+        reason: str,
+        stage: str,
+        existing: dict[str, Any] | None = None,
+        detail: Any = None,
+    ) -> dict[str, Any]:
+        record = {
+            "title": candidate.title,
+            "source_url": str(candidate.source_url),
+            "source_document_ref": candidate.source_document_ref,
+            "reason": reason,
+            "stage": stage,
+        }
+        if existing is not None:
+            record["existing_record"] = existing
+        if detail is not None:
+            record["detail"] = detail
+        return record
+
+    def _build_failure_record(
+        self,
+        candidate: ParsedScholarshipCandidate,
+        exc: Exception,
+        *,
+        phase: str,
+    ) -> dict[str, Any]:
+        return {
+            "title": candidate.title,
+            "source_url": str(candidate.source_url),
+            "source_document_ref": candidate.source_document_ref,
+            "phase": phase,
+            "error_type": exc.__class__.__name__,
+            "error_message": str(exc),
+        }
+
+    def _normalize_duplicate_reason(self, detail: Any) -> str:
+        message = str(detail).lower()
+        if "identical content" in message or "content" in message:
+            return "duplicate_content_hash"
+        if "source url" in message:
+            return "duplicate_source_url"
+        return "duplicate_record"
+
+    def _base_run_metadata(
+        self,
+        *,
+        source: SourceRegistry,
+        payload: IngestionRunStartRequest,
+        actor_user_id: uuid.UUID | None,
+    ) -> RunMetadata:
+        return RunMetadata(
+            {
+                "source": {
+                    "source_key": source.source_key,
+                    "source_display_name": source.display_name,
+                    "source_base_url": source.base_url,
+                    "source_type": source.source_type,
+                    "scope_policy": "canada_first_fulbright_us_only",
+                },
+                "request": {
+                    "max_records": payload.max_records,
+                    "execution_mode_requested": payload.execution_mode,
+                },
+                "execution": {
+                    "selected_mode": None,
+                    "dispatch_status": "created",
+                    "actor_user_id": str(actor_user_id) if actor_user_id else None,
+                    "attempt_count": 0,
+                    "retry_count": 0,
+                },
+                "capture": {},
+                "parser": {},
+                "dedup": {},
+                "created_records": [],
+                "skipped_records": [],
+                "failed_records": [],
+            }
+        )
+
+    def _build_run_metadata(
+        self,
+        *,
+        run: IngestionRun,
+        capture: CaptureResult,
+        parse_result: ParseCandidatesResult,
+        dedup_precheck: dict[str, Any],
+        created_records: list[dict[str, Any]],
+        skipped_records: list[dict[str, Any]],
+        failed_records: list[dict[str, Any]],
+        selected_candidate_count: int,
+    ) -> RunMetadata:
+        execution_state = dict((run.run_metadata or {}).get("execution") or {})
+        execution_state["retry_count"] = int(capture.metadata.get("retries_used", 0))
+        execution_state["completed_at"] = self._now().isoformat()
+
+        return self._merge_run_metadata(
+            run.run_metadata,
+            {
+                "execution": execution_state,
+                "summary": {
+                    "records_found": run.records_found,
+                    "records_created": run.records_created,
+                    "records_skipped": run.records_skipped,
+                    "failed_records": len(failed_records),
+                    "selected_candidate_count": selected_candidate_count,
+                },
+                "capture": capture.metadata,
+                "parser": parse_result.diagnostics,
+                "dedup": {
+                    **dedup_precheck["diagnostics"],
+                    "advisories": dedup_precheck["advisories"],
+                },
+                "created_records": created_records,
+                "skipped_records": skipped_records,
+                "failed_records": failed_records,
+            },
+        )
+
+    def _merge_run_metadata(
+        self,
+        existing: dict[str, Any] | None,
+        patch: dict[str, Any],
+    ) -> RunMetadata:
+        base = self._deep_copy_dict(existing or {})
+        for key, value in patch.items():
+            if isinstance(value, dict) and isinstance(base.get(key), dict):
+                base[key] = self._merge_run_metadata(base[key], value)
+            else:
+                base[key] = value
+        return RunMetadata(base)
+
+    def _deep_copy_dict(self, value: dict[str, Any]) -> dict[str, Any]:
+        copied: dict[str, Any] = {}
+        for key, item in value.items():
+            if isinstance(item, dict):
+                copied[key] = self._deep_copy_dict(item)
+            elif isinstance(item, list):
+                copied[key] = [self._deep_copy_dict(v) if isinstance(v, dict) else v for v in item]
+            else:
+                copied[key] = item
+        return copied
+
+    def _read_requested_max_records(self, run_metadata: dict[str, Any] | None) -> int:
+        request = dict((run_metadata or {}).get("request") or {})
+        max_records = request.get("max_records", DEFAULT_MAX_RECORDS)
+        try:
+            return int(max_records)
+        except (TypeError, ValueError):
+            return DEFAULT_MAX_RECORDS
+
+    def _result_items(self, result: Any) -> list[Any]:
+        scalars = getattr(result, "scalars", None)
+        if callable(scalars):
+            scalar_result = scalars()
+            all_method = getattr(scalar_result, "all", None)
+            if callable(all_method):
+                return list(all_method())
+        item = getattr(result, "item", None)
+        return [item] if item is not None else []
+
+    def _build_candidate_summary(self, title: str, context_text: str | None) -> str:
+        summary = self._clean_text(context_text or "")
         if summary:
-            summary = re.sub(r"\s+", " ", summary)[:350]
-            return f"{title}. {summary}"
+            trimmed = summary[:MAX_SUMMARY_LENGTH]
+            if trimmed.lower().startswith(title.lower()):
+                return trimmed
+            return f"{title}. {trimmed}"[: MAX_SUMMARY_LENGTH + len(title) + 2]
         return f"{title}. Imported from the approved source registry for curator review."
 
     def _extract_funding_summary(self, text: str) -> str | None:
         lowered = text.lower()
-        for keyword in ("stipend", "tuition", "funding", "award", "grant"):
+        for keyword in ("stipend", "tuition", "funding", "award", "grant", "bursary"):
             if keyword in lowered:
-                return f"Potential {keyword}-related support mentioned on the source page; curator verification required."
+                return (
+                    f"Potential {keyword}-related support mentioned on the source page; "
+                    "curator verification required."
+                )
         return None
 
     def _infer_field_tags(self, text: str) -> list[str]:
-        lowered = text.lower()
+        lowered = f" {text.lower()} "
         matched = [
             canonical
             for canonical, keywords in FIELD_KEYWORD_MAP.items()
@@ -467,10 +1062,9 @@ class IngestionService:
         return matched
 
     def _infer_degree_levels(self, text: str) -> list[str]:
-        lowered = text.lower()
-        if any(keyword in lowered for keyword in DEGREE_KEYWORDS):
-            return ["MS"]
-        return ["MS"]
+        lowered = f" {text.lower()} "
+        levels = [level for level, keywords in DEGREE_KEYWORDS if any(keyword in lowered for keyword in keywords)]
+        return levels or ["MS"]
 
     def _infer_country_code(self, source: SourceRegistry, url: str) -> str:
         lowered = f"{source.source_key} {source.display_name} {url}".lower()
@@ -478,9 +1072,11 @@ class IngestionService:
             return "US"
         return "CA"
 
-    def _looks_like_candidate(self, text: str) -> bool:
-        lowered = text.lower()
-        return any(keyword in lowered for keyword in SCHOLARSHIP_KEYWORDS)
+    def _document_ref_from_url_or_title(self, resolved_url: str, title: str) -> str:
+        path_segments = [segment for segment in urlparse(resolved_url).path.split("/") if segment]
+        if path_segments:
+            return self._slugify(path_segments[-1])
+        return self._slugify(title)
 
     def _extract_title(self, html: str) -> str | None:
         match = re.search(r"<title>(.*?)</title>", html, flags=re.IGNORECASE | re.DOTALL)
@@ -492,7 +1088,7 @@ class IngestionService:
         meta = soup.find("meta", attrs={"name": "description"}) or soup.find(
             "meta", attrs={"property": "og:description"}
         )
-        if not meta:
+        if meta is None:
             return None
         content = meta.get("content")
         return self._clean_text(content) if content else None
@@ -502,21 +1098,33 @@ class IngestionService:
 
     def _slugify(self, value: str) -> str:
         slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
-        return slug[:255]
+        return slug[:255] or "item"
 
     def _resolve_run_status(
         self,
+        *,
         records_found: int,
         records_created: int,
         records_skipped: int,
+        failure_count: int,
     ) -> IngestionRunStatus:
-        if records_created > 0 and records_skipped == 0:
+        if records_created > 0 and records_skipped == 0 and failure_count == 0 and records_found == records_created:
             return IngestionRunStatus.COMPLETED
-        if records_created > 0 or records_found > 0 or records_skipped > 0:
+        if records_created > 0 or records_skipped > 0 or failure_count > 0 or records_found > 0:
             return IngestionRunStatus.PARTIAL
         return IngestionRunStatus.FAILED
 
     def _build_summary(self, run: IngestionRun) -> IngestionRunSummary:
+        metadata = run.run_metadata or {}
+        execution = metadata.get("execution") or {}
+        request = metadata.get("request") or {}
+
+        def _as_int(value: Any) -> int:
+            try:
+                return int(value) if value is not None else 0
+            except (TypeError, ValueError):
+                return 0
+
         return IngestionRunSummary(
             run_id=str(run.id),
             source_key=run.source_registry.source_key,
@@ -525,13 +1133,17 @@ class IngestionService:
             status=run.status.value,
             capture_mode=run.capture_mode,
             parser_name=run.parser_name,
-            records_found=run.records_found,
-            records_created=run.records_created,
-            records_skipped=run.records_skipped,
+            records_found=_as_int(run.records_found),
+            records_created=_as_int(run.records_created),
+            records_skipped=_as_int(run.records_skipped),
             failure_reason=run.failure_reason,
             started_at=run.started_at,
             completed_at=run.completed_at,
             created_at=run.created_at,
+            execution_mode_requested=request.get("execution_mode_requested"),
+            execution_mode_selected=execution.get("selected_mode"),
+            dispatch_status=execution.get("dispatch_status"),
+            celery_task_id=execution.get("celery_task_id"),
         )
 
     def _build_detail(self, run: IngestionRun) -> IngestionRunDetail:
@@ -539,3 +1151,6 @@ class IngestionService:
             **self._build_summary(run).model_dump(),
             run_metadata=run.run_metadata,
         )
+
+    def _now(self) -> datetime:
+        return datetime.now(timezone.utc)

--- a/backend/app/services/recommendations/eligibility.py
+++ b/backend/app/services/recommendations/eligibility.py
@@ -134,20 +134,20 @@ def field_alignment_score(target_field: str, field_tags: list[str]) -> float:
 def scholarship_in_scope(scholarship: Scholarship) -> tuple[bool, str, float]:
     haystack = " ".join(
         [
-            scholarship.title or "",
-            scholarship.provider_name or "",
-            scholarship.source_url or "",
-            scholarship.summary or "",
+            getattr(scholarship, "title", "") or "",
+            getattr(scholarship, "provider_name", "") or "",
+            getattr(scholarship, "source_url", "") or "",
+            getattr(scholarship, "summary", "") or "",
         ]
     ).lower()
 
     if "daad" in haystack:
         return False, "DAAD records remain deferred in Phase 1.", 0.0
 
-    if scholarship.country_code == "CA":
+    if getattr(scholarship, "country_code", "").upper() == "CA":
         return True, "Canada remains the primary recommendation market in Phase 1.", 1.0
 
-    if scholarship.country_code == "US" and "fulbright" in haystack:
+    if getattr(scholarship, "country_code", "").upper() == "US" and "fulbright" in haystack:
         return True, "US scope is limited to Fulbright-adjacent records while Canada stays first.", 0.82
 
     return False, "Phase 1 scope keeps non-Canada records deferred unless they are Fulbright-related.", 0.0

--- a/backend/app/services/saved_opportunities/service.py
+++ b/backend/app/services/saved_opportunities/service.py
@@ -30,7 +30,7 @@ class SavedOpportunityService:
             for application in saved_rows
             if application.scholarship is not None
             and application.scholarship.record_state == RecordState.PUBLISHED
-            and scholarship_in_scope(application.scholarship)
+            and self._is_in_scope(application.scholarship)
         ]
 
     async def save(self, user_id: uuid.UUID, scholarship_id: uuid.UUID) -> SavedOpportunityItem:
@@ -87,12 +87,16 @@ class SavedOpportunityService:
             )
         )
         scholarship = result.scalar_one_or_none()
-        if scholarship is None or not scholarship_in_scope(scholarship):
+        if scholarship is None or not self._is_in_scope(scholarship):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Published scholarship not found",
             )
         return scholarship
+
+    def _is_in_scope(self, scholarship: Scholarship) -> bool:
+        in_scope, _, _ = scholarship_in_scope(scholarship)
+        return in_scope
 
     def _serialize(self, application: Application) -> SavedOpportunityItem:
         scholarship = application.scholarship

--- a/backend/app/tasks/recommendation_tasks.py
+++ b/backend/app/tasks/recommendation_tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 
 from app.core.database import async_session_factory
 from app.services.recommendations.embedding_refresh import (
@@ -23,8 +24,39 @@ async def _run_embedding_refresh(limit: int | None = None) -> dict[str, int | bo
         return await refresher.refresh_published_scholarships(limit=limit)
 
 
+def _run_coro_sync(coro):
+    """
+    Run an async coroutine from sync code.
+
+    Celery workers call this task in a normal sync context (no running loop),
+    while some unit tests invoke it from an active event loop thread.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    result: dict[str, int | bool] = {}
+    error: Exception | None = None
+
+    def runner() -> None:
+        nonlocal error
+        try:
+            result["value"] = asyncio.run(coro)
+        except Exception as exc:  # pragma: no cover - defensive bridge
+            error = exc
+
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+    thread.join()
+
+    if error is not None:
+        raise error
+    return result["value"]
+
+
 @celery_app.task(name="tasks.refresh_published_scholarship_embeddings")
 def refresh_published_scholarship_embeddings(
     limit: int | None = None,
 ) -> dict[str, int | bool]:
-    return asyncio.run(_run_embedding_refresh(limit=limit))
+    return _run_coro_sync(_run_embedding_refresh(limit=limit))

--- a/backend/app/tasks/scraper_tasks.py
+++ b/backend/app/tasks/scraper_tasks.py
@@ -7,10 +7,44 @@ from app.schemas.curation import IngestionRunStartRequest
 from app.tasks.celery_app import celery_app
 
 
+def _extract_run_diagnostics(run_metadata: dict | None) -> dict[str, str | None]:
+    metadata = run_metadata if isinstance(run_metadata, dict) else {}
+    execution = metadata.get("execution")
+    execution_context = execution if isinstance(execution, dict) else {}
+    return {
+        "execution_mode_requested": (
+            execution_context.get("requested_mode")
+            or metadata.get("requested_mode")
+            or metadata.get("execution_mode_requested")
+        ),
+        "execution_mode_selected": (
+            execution_context.get("selected_mode")
+            or metadata.get("selected_mode")
+            or metadata.get("execution_mode_selected")
+        ),
+        "dispatch_status": (
+            execution_context.get("dispatch_status")
+            or metadata.get("dispatch_status")
+        ),
+        "celery_task_id": (
+            execution_context.get("celery_task_id")
+            or metadata.get("celery_task_id")
+        ),
+    }
+
+
+def _detail_to_payload(detail) -> dict:
+    payload = detail.model_dump()
+    run_metadata = payload.get("run_metadata")
+    payload.update(_extract_run_diagnostics(run_metadata))
+    return payload
+
+
 @celery_app.task(name="tasks.run_source_ingestion")
 def run_source_ingestion(
-    source_key: str,
-    actor_user_id: str,
+    run_id: str | None = None,
+    source_key: str | None = None,
+    actor_user_id: str | None = None,
     source_display_name: str | None = None,
     source_base_url: str | None = None,
     source_type: str = "official",
@@ -18,6 +52,7 @@ def run_source_ingestion(
 ) -> dict:
     return asyncio.run(
         _run_source_ingestion_async(
+            run_id=run_id,
             source_key=source_key,
             actor_user_id=actor_user_id,
             source_display_name=source_display_name,
@@ -30,8 +65,9 @@ def run_source_ingestion(
 
 async def _run_source_ingestion_async(
     *,
-    source_key: str,
-    actor_user_id: str,
+    run_id: str | None,
+    source_key: str | None,
+    actor_user_id: str | None,
     source_display_name: str | None,
     source_base_url: str | None,
     source_type: str,
@@ -39,18 +75,46 @@ async def _run_source_ingestion_async(
 ) -> dict:
     async with async_session_factory() as session:
         service = IngestionService(session)
-        detail = await service.start_run(
-            IngestionRunStartRequest(
+        if run_id:
+            detail = await service.execute_run(
+                uuid.UUID(run_id),
+                actor_user_id=uuid.UUID(actor_user_id) if actor_user_id else None,
+                max_records=max_records,
+                execution_context={
+                    "selected_mode": "worker",
+                    "dispatch_status": "running",
+                },
+                persist_running_state=True,
+            )
+        else:
+            if source_key is None or actor_user_id is None:
+                raise ValueError("source_key and actor_user_id are required when run_id is not provided")
+            actor_id = uuid.UUID(actor_user_id)
+            payload = IngestionRunStartRequest(
                 source_key=source_key,
                 source_display_name=source_display_name,
                 source_base_url=source_base_url,
                 source_type=source_type,
                 max_records=max_records,
-            ),
-            uuid.UUID(actor_user_id),
-        )
+                execution_mode="worker",
+            )
+            if hasattr(service, "create_run") and hasattr(service, "execute_run"):
+                created_run = await service.create_run(payload, actor_id)
+                detail = await service.execute_run(
+                    uuid.UUID(created_run.run_id),
+                    actor_user_id=actor_id,
+                    max_records=max_records,
+                    execution_context={
+                        "requested_mode": "worker",
+                        "selected_mode": "worker",
+                        "dispatch_status": "running",
+                    },
+                    persist_running_state=True,
+                )
+            else:
+                detail = await service.start_run(payload, actor_id)
         await session.commit()
-        return detail.model_dump()
+        return _detail_to_payload(detail)
 
 
 @celery_app.task(name="tasks.run_nightly_ingestion")
@@ -63,11 +127,12 @@ def run_nightly_ingestion() -> dict:
     
     return asyncio.run(
         _run_source_ingestion_async(
+            run_id=None,
             source_key="nightly_sync_main",
             actor_user_id=SYSTEM_ADMIN_ID,
             source_display_name="Auto Nightly Ingestion",
             source_base_url=None,
             source_type="official",
-            max_records=50,
+            max_records=20,
         )
     )

--- a/backend/scholarai_common/logging.py
+++ b/backend/scholarai_common/logging.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+import os
+
+
+def setup_logging(level: str | int | None = None) -> None:
+    """
+    Configure process-wide logging once.
+
+    This is intentionally lightweight so it can be imported safely from both
+    app runtime and tests without side effects beyond standard logging setup.
+    """
+    resolved_level = level or os.getenv("LOG_LEVEL", "INFO")
+    if isinstance(resolved_level, str):
+        numeric_level = logging.getLevelName(resolved_level.upper())
+        if isinstance(numeric_level, str):
+            numeric_level = logging.INFO
+    else:
+        numeric_level = int(resolved_level)
+
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
+        root_logger.setLevel(numeric_level)
+        return
+
+    logging.basicConfig(
+        level=numeric_level,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )
+
+
+def get_logger(name: str) -> logging.Logger:
+    return logging.getLogger(name)
+

--- a/backend/scholarai_common/models.py
+++ b/backend/scholarai_common/models.py
@@ -1,10 +1,18 @@
 from enum import Enum
 
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass
+
+
 class RecordState(str, Enum):
     RAW = "raw"
     VALIDATED = "validated"
     PUBLISHED = "published"
     ARCHIVED = "archived"
+
 
 class InterviewPracticeMode(str, Enum):
     GENERAL = "general"

--- a/backend/tests/unit/test_auth_service.py
+++ b/backend/tests/unit/test_auth_service.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from app.core.security import hash_password
 from app.schemas.auth import UserCreate, UserLogin
 from app.services.auth import AuthService
+from scholarai_common.errors import ScholarAIException, ErrorCode
 
 pytestmark = pytest.mark.asyncio
 
@@ -62,12 +63,13 @@ async def test_auth_service_login_rejects_invalid_password():
     session = FakeSession([ScalarResult(one=user)])
     service = AuthService(session)
 
-    tokens, error_code = await service.login(
-        UserLogin(email="student@example.com", password="wrong-password")
-    )
+    with pytest.raises(ScholarAIException) as caught:
+        await service.login(
+            UserLogin(email="student@example.com", password="wrong-password")
+        )
 
-    assert tokens is None
-    assert error_code == "invalid_credentials"
+    assert caught.value.code == ErrorCode.AUTH_INVALID_CREDENTIALS
+    assert caught.value.status_code == 401
 
 
 async def test_auth_service_login_returns_tokens_for_valid_credentials():
@@ -81,11 +83,10 @@ async def test_auth_service_login_returns_tokens_for_valid_credentials():
     session = FakeSession([ScalarResult(one=user)])
     service = AuthService(session)
 
-    tokens, error_code = await service.login(
+    tokens = await service.login(
         UserLogin(email="student@example.com", password="correct-password")
     )
 
-    assert error_code is None
     assert tokens is not None
     assert tokens.access_token
     assert tokens.refresh_token
@@ -99,10 +100,10 @@ async def test_auth_service_refresh_session_returns_new_tokens():
         role=SimpleNamespace(value="student"),
         is_active=True,
     )
-    session = FakeSession([ScalarResult(one=user)])
+    session = FakeSession([ScalarResult(one=user), ScalarResult(one=user)])
     service = AuthService(session)
 
-    login_tokens, _ = await service.login(
+    login_tokens = await service.login(
         UserLogin(email="student@example.com", password="correct-password")
     )
     assert login_tokens is not None

--- a/backend/tests/unit/test_ingestion_service.py
+++ b/backend/tests/unit/test_ingestion_service.py
@@ -1,11 +1,16 @@
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
 
-from app.models import IngestionRunStatus, SourceRegistry
+from app.models import IngestionRun, IngestionRunStatus, SourceRegistry
 from app.schemas.curation import IngestionRunStartRequest
-from app.services.ingestion.service import CaptureResult, IngestionService
+from app.services.ingestion.service import (
+    CaptureResult,
+    IngestionService,
+    retry_async,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -13,9 +18,14 @@ pytestmark = pytest.mark.asyncio
 class FakeSession:
     def __init__(self):
         self.added = []
+        self.run = None
         self.source = None
+        self.execute_calls = 0
 
     async def execute(self, _query):
+        self.execute_calls += 1
+        if self.run is not None and self.execute_calls > 1:
+            return FakeResult(self.run)
         return FakeResult(self.source)
 
     def add(self, value):
@@ -25,6 +35,8 @@ class FakeSession:
             value.created_at = datetime.now(timezone.utc)
         if getattr(value, "updated_at", None) is None:
             value.updated_at = datetime.now(timezone.utc)
+        if isinstance(value, IngestionRun):
+            self.run = value
         self.added.append(value)
 
     async def flush(self):
@@ -53,88 +65,146 @@ def make_source() -> SourceRegistry:
     return source
 
 
-async def test_parse_candidates_extracts_scholarship_like_links():
-    service = IngestionService(FakeSession())
-    source = make_source()
-    capture = CaptureResult(
-        html="""
-        <html>
-          <head>
-            <title>Graduate Funding</title>
-            <meta name="description" content="Data science and AI graduate scholarships for master's students." />
-          </head>
-          <body>
-            <a href="/awards/data-science-scholarship">Data Science Scholarship</a>
-            <a href="/awards/analytics-award">Analytics Award</a>
-          </body>
-        </html>
-        """,
-        final_url=source.base_url,
-        title="Graduate Funding",
+def make_capture(
+    html: str,
+    *,
+    final_url: str | None = None,
+    title: str | None = "Graduate Funding",
+) -> CaptureResult:
+    return CaptureResult(
+        html=html,
+        final_url=final_url or "https://uwaterloo.ca/graduate-studies-postdoctoral-affairs/funding",
+        title=title,
         capture_mode="httpx_fallback",
-        metadata={},
+        metadata={
+            "requested_url": final_url or "https://uwaterloo.ca/graduate-studies-postdoctoral-affairs/funding",
+            "status_code": 200,
+        },
     )
 
-    candidates = service._parse_candidates(source, capture)
 
-    assert len(candidates) == 2
-    assert candidates[0].country_code == "CA"
-    assert "data science" in candidates[0].field_tags
-    assert candidates[0].degree_levels == ["MS"]
+async def test_start_run_creates_raw_record_from_source_page(monkeypatch):
+    session = FakeSession()
+    session.source = make_source()
+    service = IngestionService(session)
+    actor_user_id = uuid4()
+    captured_calls = []
+
+    async def fake_capture(_url: str) -> CaptureResult:
+        return make_capture(
+            """
+            <html>
+              <head>
+                <title>Funding</title>
+                <meta name="description" content="Funding for data science master's students." />
+              </head>
+              <body>
+                <a href="/awards/data-science-scholarship">Data Science Scholarship</a>
+              </body>
+            </html>
+            """
+        )
+
+    class RecordingCurationService:
+        def __init__(self, _db):
+            pass
+
+        async def import_raw_record(self, payload, actor_id):
+            captured_calls.append((payload, actor_id))
+            return SimpleNamespace(
+                record_id=str(uuid4()),
+                title=payload.title,
+                source_url=str(payload.source_url),
+            )
+
+    monkeypatch.setattr(service, "_capture_source", fake_capture)
+    monkeypatch.setattr(
+        "app.services.ingestion.service.CurationService",
+        RecordingCurationService,
+    )
+
+    detail = await service.start_run(
+        IngestionRunStartRequest(source_key=session.source.source_key, max_records=5),
+        actor_user_id,
+    )
+
+    payload, imported_actor_id = captured_calls[0]
+    assert detail.status == IngestionRunStatus.COMPLETED.value
+    assert detail.records_found == 1
+    assert detail.records_created == 1
+    assert detail.records_skipped == 0
+    assert detail.run_metadata["capture"]["status_code"] == 200
+    assert detail.run_metadata["created_records"][0]["title"] == "Data Science Scholarship"
+    assert imported_actor_id == actor_user_id
+    assert payload.title == "Data Science Scholarship"
+    assert str(payload.source_url).endswith("/awards/data-science-scholarship")
+    assert payload.source_document_ref == "data-science-scholarship"
+    assert payload.field_tags == ["data science"]
+    assert payload.degree_levels == ["MS"]
+    assert payload.review_notes == "Auto-imported from source registry page for curator review."
+    assert payload.provenance_payload["ingested_via"] == "source_registry_run"
 
 
-async def test_start_run_records_created_and_partial_status(monkeypatch):
+async def test_start_run_marks_duplicates_as_skipped(monkeypatch):
     session = FakeSession()
     session.source = make_source()
     service = IngestionService(session)
     actor_user_id = uuid4()
 
     async def fake_capture(_url: str) -> CaptureResult:
-        return CaptureResult(
-            html="""
+        return make_capture(
+            """
             <html>
-              <head><title>Funding</title></head>
+              <head>
+                <title>Funding</title>
+                <meta name="description" content="Funding for data science and analytics students." />
+              </head>
               <body>
                 <a href="/awards/data-science-scholarship">Data Science Scholarship</a>
                 <a href="/awards/analytics-award">Analytics Award</a>
               </body>
             </html>
-            """,
-            final_url=session.source.base_url,
-            title="Funding",
-            capture_mode="httpx_fallback",
-            metadata={},
+            """
         )
 
-    class FakeCurationService:
-        call_count = 0
-
+    class RecordingCurationService:
         def __init__(self, _db):
-            pass
+            self.calls = []
 
         async def import_raw_record(self, payload, actor_id):
-            FakeCurationService.call_count += 1
-            if FakeCurationService.call_count == 1:
-                return type(
-                    "Detail",
-                    (),
-                    {
-                        "record_id": str(uuid4()),
-                        "title": payload.title,
-                        "source_url": payload.source_url,
-                    },
-                )()
-            from fastapi import HTTPException, status
-
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="duplicate",
+            self.calls.append((payload, actor_id))
+            return SimpleNamespace(
+                record_id=str(uuid4()),
+                title=payload.title,
+                source_url=str(payload.source_url),
             )
 
+    existing = SimpleNamespace(
+        id=uuid4(),
+        title="Data Science Scholarship",
+        source_url="https://uwaterloo.ca/awards/data-science-scholarship",
+        source_document_ref="data-science-scholarship",
+        content_hash="hash-1",
+    )
+
+    async def fake_find_existing(where_clause):
+        left = getattr(where_clause, "left", None)
+        right = getattr(where_clause, "right", None)
+        key = getattr(left, "key", None)
+        value = getattr(right, "value", None)
+        if (
+            key == "source_url"
+            and isinstance(value, str)
+            and value.endswith("/awards/data-science-scholarship")
+        ):
+            return existing
+        return None
+
     monkeypatch.setattr(service, "_capture_source", fake_capture)
+    monkeypatch.setattr(service, "_find_existing_scholarship", fake_find_existing)
     monkeypatch.setattr(
         "app.services.ingestion.service.CurationService",
-        FakeCurationService,
+        RecordingCurationService,
     )
 
     detail = await service.start_run(
@@ -143,5 +213,58 @@ async def test_start_run_records_created_and_partial_status(monkeypatch):
     )
 
     assert detail.status == IngestionRunStatus.PARTIAL.value
+    assert detail.records_found == 2
     assert detail.records_created == 1
     assert detail.records_skipped == 1
+    assert detail.run_metadata["created_records"][0]["title"] == "Analytics Award"
+    assert detail.run_metadata["dedup"]["source_url_matches"] == 1
+    assert detail.run_metadata["skipped_records"][0]["reason"] == "duplicate_source_url"
+
+
+async def test_retry_async_retries_flaky_coroutine(monkeypatch):
+    sleep_calls = []
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr("app.services.ingestion.service.asyncio.sleep", fake_sleep)
+
+    attempts = {"count": 0}
+
+    @retry_async(max_retries=3, delay=0.5)
+    async def flaky():
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise RuntimeError("temporary capture failure")
+        return "ok"
+
+    result = await flaky()
+
+    assert result == "ok"
+    assert attempts["count"] == 3
+    assert sleep_calls == [0.5, 1.0]
+
+
+async def test_start_run_records_failure_metadata_when_capture_fails(monkeypatch):
+    session = FakeSession()
+    session.source = make_source()
+    service = IngestionService(session)
+
+    async def failing_capture(_url: str) -> CaptureResult:
+        raise RuntimeError("capture unavailable")
+
+    monkeypatch.setattr(service, "_capture_source", failing_capture)
+
+    with pytest.raises(RuntimeError, match="capture unavailable"):
+        await service.start_run(
+            IngestionRunStartRequest(source_key=session.source.source_key, max_records=5),
+            uuid4(),
+        )
+
+    run = session.run
+    assert run is not None
+    assert run.status == IngestionRunStatus.FAILED
+    assert run.failure_reason == "capture unavailable"
+    assert run.run_metadata["error_type"] == "RuntimeError"
+    assert run.run_metadata["failure"]["phase"] == "capture_or_parse"
+    assert run.run_metadata["failure"]["error_message"] == "capture unavailable"

--- a/backend/tests/unit/test_scraper_tasks.py
+++ b/backend/tests/unit/test_scraper_tasks.py
@@ -1,0 +1,281 @@
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+
+pytest.importorskip("celery")
+
+from app.tasks import scraper_tasks
+
+
+class FakeDetail:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def model_dump(self):
+        return self.payload
+
+
+class FakeSession:
+    def __init__(self):
+        self.commits = 0
+
+    async def commit(self):
+        self.commits += 1
+
+
+class FakeSessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def make_run_payload(run_id: str) -> dict:
+    return {
+        "run_id": run_id,
+        "source_key": "waterloo-awards",
+        "source_display_name": "University of Waterloo Graduate Funding",
+        "fetch_url": "https://uwaterloo.ca/graduate-studies-postdoctoral-affairs/funding",
+        "status": "partial",
+        "capture_mode": "httpx_fallback",
+        "parser_name": "official_page_parser_v3",
+        "records_found": 2,
+        "records_created": 1,
+        "records_skipped": 1,
+        "failure_reason": None,
+        "started_at": None,
+        "completed_at": None,
+        "created_at": "2026-03-20T00:00:00+00:00",
+        "run_metadata": {
+            "execution": {
+                "requested_mode": "worker",
+                "selected_mode": "worker",
+                "dispatch_status": "running",
+                "celery_task_id": "celery-123",
+            }
+        },
+    }
+
+
+def test_run_source_ingestion_executes_existing_run_when_run_id_provided(monkeypatch):
+    session = FakeSession()
+    captured = {}
+
+    class FakeIngestionService:
+        def __init__(self, db):
+            captured["db"] = db
+
+        async def execute_run(
+            self,
+            run_id,
+            *,
+            actor_user_id,
+            max_records,
+            execution_context,
+            persist_running_state,
+        ):
+            captured["execute"] = {
+                "run_id": run_id,
+                "actor_user_id": actor_user_id,
+                "max_records": max_records,
+                "execution_context": execution_context,
+                "persist_running_state": persist_running_state,
+            }
+            payload = make_run_payload(str(run_id))
+            return FakeDetail(payload)
+
+    monkeypatch.setattr(
+        scraper_tasks,
+        "async_session_factory",
+        lambda: FakeSessionContext(session),
+    )
+    monkeypatch.setattr(scraper_tasks, "IngestionService", FakeIngestionService)
+
+    run_id = str(uuid4())
+    result = scraper_tasks.run_source_ingestion(run_id=run_id, max_records=7)
+
+    assert captured["db"] is session
+    assert captured["execute"]["run_id"] == UUID(run_id)
+    assert captured["execute"]["actor_user_id"] is None
+    assert captured["execute"]["max_records"] == 7
+    assert captured["execute"]["execution_context"] == {
+        "selected_mode": "worker",
+        "dispatch_status": "running",
+    }
+    assert captured["execute"]["persist_running_state"] is True
+    assert result["run_id"] == run_id
+    assert result["execution_mode_selected"] == "worker"
+    assert result["dispatch_status"] == "running"
+    assert result["celery_task_id"] == "celery-123"
+    assert session.commits == 1
+
+
+def test_run_source_ingestion_creates_and_executes_worker_run(monkeypatch):
+    session = FakeSession()
+    captured = {}
+    created_run_id = str(uuid4())
+
+    class FakeIngestionService:
+        def __init__(self, db):
+            captured["db"] = db
+
+        async def create_run(self, payload, actor_user_id):
+            captured["create"] = {
+                "payload": payload,
+                "actor_user_id": actor_user_id,
+            }
+            return SimpleNamespace(run_id=created_run_id)
+
+        async def execute_run(
+            self,
+            run_id,
+            *,
+            actor_user_id,
+            max_records,
+            execution_context,
+            persist_running_state,
+        ):
+            captured["execute"] = {
+                "run_id": run_id,
+                "actor_user_id": actor_user_id,
+                "max_records": max_records,
+                "execution_context": execution_context,
+                "persist_running_state": persist_running_state,
+            }
+            payload = make_run_payload(str(run_id))
+            return FakeDetail(payload)
+
+    monkeypatch.setattr(
+        scraper_tasks,
+        "async_session_factory",
+        lambda: FakeSessionContext(session),
+    )
+    monkeypatch.setattr(scraper_tasks, "IngestionService", FakeIngestionService)
+
+    actor_user_id = str(uuid4())
+    result = scraper_tasks.run_source_ingestion(
+        source_key="waterloo-awards",
+        actor_user_id=actor_user_id,
+        source_display_name="University of Waterloo Graduate Funding",
+        source_base_url="https://uwaterloo.ca/graduate-studies-postdoctoral-affairs/funding",
+        source_type="official",
+        max_records=3,
+    )
+
+    assert captured["db"] is session
+    assert captured["create"]["actor_user_id"] == UUID(actor_user_id)
+    assert captured["create"]["payload"].source_key == "waterloo-awards"
+    assert captured["create"]["payload"].execution_mode == "worker"
+    assert captured["execute"]["run_id"] == UUID(created_run_id)
+    assert captured["execute"]["actor_user_id"] == UUID(actor_user_id)
+    assert captured["execute"]["max_records"] == 3
+    assert captured["execute"]["execution_context"] == {
+        "requested_mode": "worker",
+        "selected_mode": "worker",
+        "dispatch_status": "running",
+    }
+    assert captured["execute"]["persist_running_state"] is True
+    assert result["run_id"] == created_run_id
+    assert result["execution_mode_selected"] == "worker"
+    assert session.commits == 1
+
+
+def test_run_source_ingestion_falls_back_to_start_run_for_legacy_service(monkeypatch):
+    session = FakeSession()
+    captured = {}
+
+    class FakeIngestionService:
+        def __init__(self, db):
+            captured["db"] = db
+
+        async def start_run(self, payload, actor_user_id):
+            captured["start_run"] = {
+                "payload": payload,
+                "actor_user_id": actor_user_id,
+            }
+            return FakeDetail(make_run_payload(str(uuid4())))
+
+    monkeypatch.setattr(
+        scraper_tasks,
+        "async_session_factory",
+        lambda: FakeSessionContext(session),
+    )
+    monkeypatch.setattr(scraper_tasks, "IngestionService", FakeIngestionService)
+
+    actor_user_id = str(uuid4())
+    result = scraper_tasks.run_source_ingestion(
+        source_key="waterloo-awards",
+        actor_user_id=actor_user_id,
+        source_display_name="University of Waterloo Graduate Funding",
+        source_base_url="https://uwaterloo.ca/graduate-studies-postdoctoral-affairs/funding",
+        source_type="official",
+        max_records=3,
+    )
+
+    assert captured["db"] is session
+    assert captured["start_run"]["actor_user_id"] == UUID(actor_user_id)
+    assert captured["start_run"]["payload"].execution_mode == "worker"
+    assert result["execution_mode_selected"] == "worker"
+    assert session.commits == 1
+
+
+def test_run_nightly_ingestion_uses_reserved_system_identity(monkeypatch):
+    session = FakeSession()
+    captured = {}
+    created_run_id = str(uuid4())
+
+    class FakeIngestionService:
+        def __init__(self, db):
+            captured["db"] = db
+
+        async def create_run(self, payload, actor_user_id):
+            captured["create"] = {
+                "payload": payload,
+                "actor_user_id": actor_user_id,
+            }
+            return SimpleNamespace(run_id=created_run_id)
+
+        async def execute_run(
+            self,
+            run_id,
+            *,
+            actor_user_id,
+            max_records,
+            execution_context,
+            persist_running_state,
+        ):
+            captured["execute"] = {
+                "run_id": run_id,
+                "actor_user_id": actor_user_id,
+                "max_records": max_records,
+                "execution_context": execution_context,
+                "persist_running_state": persist_running_state,
+            }
+            return FakeDetail(make_run_payload(str(run_id)))
+
+    monkeypatch.setattr(
+        scraper_tasks,
+        "async_session_factory",
+        lambda: FakeSessionContext(session),
+    )
+    monkeypatch.setattr(scraper_tasks, "IngestionService", FakeIngestionService)
+
+    result = scraper_tasks.run_nightly_ingestion()
+
+    assert captured["db"] is session
+    assert captured["create"]["payload"].source_key == "nightly_sync_main"
+    assert captured["create"]["payload"].source_display_name == "Auto Nightly Ingestion"
+    assert captured["create"]["payload"].source_base_url is None
+    assert captured["create"]["payload"].source_type == "official"
+    assert captured["create"]["payload"].max_records == 20
+    assert captured["create"]["payload"].execution_mode == "worker"
+    assert captured["create"]["actor_user_id"] == UUID("00000000-0000-0000-0000-000000000000")
+    assert captured["execute"]["run_id"] == UUID(created_run_id)
+    assert captured["execute"]["max_records"] == 20
+    assert result["run_id"] == created_run_id
+    assert session.commits == 1

--- a/backend/tests/unit/test_security.py
+++ b/backend/tests/unit/test_security.py
@@ -1,7 +1,7 @@
 import pytest
-from fastapi import HTTPException
 
 from app.core.security import create_access_token, create_refresh_token, decode_token
+from scholarai_common.errors import ScholarAIException, ErrorCode
 
 
 def test_decode_token_accepts_matching_token_type():
@@ -15,7 +15,8 @@ def test_decode_token_accepts_matching_token_type():
 def test_decode_token_rejects_wrong_token_type():
     token = create_access_token({"sub": "user-1", "role": "student"})
 
-    with pytest.raises(HTTPException) as caught:
+    with pytest.raises(ScholarAIException) as caught:
         decode_token(token, expected_type="refresh")
 
     assert caught.value.status_code == 401
+    assert caught.value.code == ErrorCode.AUTH_TOKEN_EXPIRED

--- a/frontend/src/components/curation/curation-dashboard-shell.tsx
+++ b/frontend/src/components/curation/curation-dashboard-shell.tsx
@@ -15,6 +15,7 @@ import type {
   CurationRecordListResponse,
   CurationRawImportRequest,
   CurationRecordState,
+  IngestionExecutionMode,
   IngestionRunDetail,
   IngestionRunListResponse,
   IngestionRunStartRequest,
@@ -99,6 +100,7 @@ type IngestionState = {
   source_base_url: string;
   source_type: string;
   max_records: string;
+  execution_mode: IngestionExecutionMode;
 };
 
 const EMPTY_EDIT_STATE: EditState = {
@@ -134,6 +136,7 @@ const EMPTY_INGESTION_STATE: IngestionState = {
   source_base_url: CURATION_SOURCE_OPTIONS[0].source_base_url,
   source_type: CURATION_SOURCE_OPTIONS[0].source_type,
   max_records: "5",
+  execution_mode: "auto",
 };
 
 export function CurationDashboardShell() {
@@ -532,6 +535,7 @@ export function CurationDashboardShell() {
         source_base_url: emptyToNull(ingestionState.source_base_url),
         source_type: ingestionState.source_type.trim() || "official",
         max_records: Number(ingestionState.max_records) || 5,
+        execution_mode: ingestionState.execution_mode,
       };
 
       const detail = await apiRequest<IngestionRunDetail>("/curation/ingestion-runs", {
@@ -638,6 +642,7 @@ export function CurationDashboardShell() {
                     source_base_url: selected.source_base_url,
                     source_type: selected.source_type,
                     max_records: ingestionState.max_records,
+                    execution_mode: ingestionState.execution_mode,
                   });
                 }}
                 value={ingestionState.source_key}
@@ -715,6 +720,23 @@ export function CurationDashboardShell() {
                 value={ingestionState.max_records}
               />
             </label>
+            <label className="form-field">
+              <span className="form-field__label">Execution mode</span>
+              <select
+                className="text-input"
+                onChange={(event) =>
+                  setIngestionState((current) => ({
+                    ...current,
+                    execution_mode: event.target.value as IngestionExecutionMode,
+                  }))
+                }
+                value={ingestionState.execution_mode}
+              >
+                <option value="auto">Auto (queue first)</option>
+                <option value="worker">Worker only</option>
+                <option value="inline">Inline only</option>
+              </select>
+            </label>
           </div>
           <div className="document-actions">
             <button
@@ -759,7 +781,8 @@ export function CurationDashboardShell() {
                   </div>
                   <h3 className="route-card__title">{run.source_display_name}</h3>
                   <p className="route-card__description">
-                    Created {run.records_created} · Skipped {run.records_skipped}
+                    Created {run.records_created} · Skipped {run.records_skipped} ·{" "}
+                    {run.execution_mode_selected ?? "mode-unknown"}
                   </p>
                 </button>
               ))}
@@ -782,6 +805,20 @@ export function CurationDashboardShell() {
                 <li>Found: {state.selectedRun.records_found}</li>
                 <li>Created: {state.selectedRun.records_created}</li>
                 <li>Skipped: {state.selectedRun.records_skipped}</li>
+                <li>
+                  Requested mode:{" "}
+                  {state.selectedRun.execution_mode_requested ?? "unspecified"}
+                </li>
+                <li>
+                  Selected mode:{" "}
+                  {state.selectedRun.execution_mode_selected ?? "unknown"}
+                </li>
+                <li>
+                  Dispatch status: {state.selectedRun.dispatch_status ?? "n/a"}
+                </li>
+                <li>
+                  Celery task id: {state.selectedRun.celery_task_id ?? "n/a"}
+                </li>
                 <li>
                   Completed:{" "}
                   {state.selectedRun.completed_at

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -375,6 +375,8 @@ export type IngestionRunStatus =
   | "partial"
   | "failed";
 
+export type IngestionExecutionMode = "inline" | "worker" | "auto";
+
 export type IngestionRunSummary = {
   run_id: string;
   source_key: string;
@@ -390,6 +392,10 @@ export type IngestionRunSummary = {
   started_at: string | null;
   completed_at: string | null;
   created_at: string;
+  execution_mode_requested: IngestionExecutionMode | null;
+  execution_mode_selected: IngestionExecutionMode | null;
+  dispatch_status: string | null;
+  celery_task_id: string | null;
 };
 
 export type IngestionRunDetail = IngestionRunSummary & {
@@ -407,6 +413,7 @@ export type IngestionRunStartRequest = {
   source_base_url?: string | null;
   source_type: string;
   max_records: number;
+  execution_mode?: IngestionExecutionMode;
 };
 
 export type CurationRawImportRequest = {


### PR DESCRIPTION
Replace fragile ingestion paths with explicit run-state handling, dedup logic, and retry metadata.

Align curation API/frontend contracts and recommendation task behavior with the new ingestion output.

Add scraper task unit coverage and update ingestion/auth/security tests to lock in behavior.