### PR TITLE
ci(docs): add docs-governance terminology/link/canonical-tail gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,30 @@ jobs:
       - name: Build frontend
         run: npm run build
 
+  docs-governance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run docs governance checks
+        run: |
+          python scripts/docs_governance_check.py | tee /tmp/docs-governance.out
+
+      - name: Publish docs governance summary
+        if: always()
+        run: |
+          {
+            echo "## Docs Governance"
+            echo ""
+            sed -n '/^Docs governance summary:/,$p' /tmp/docs-governance.out
+          } >> "$GITHUB_STEP_SUMMARY"
+
   browser-smoke:
     runs-on: ubuntu-latest
     services:

--- a/scripts/docs_governance_check.py
+++ b/scripts/docs_governance_check.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""ScholarAI docs governance checks.
+
+Checks:
+1) Terminology gate: blocks MVP/Post-MVP wording in README/docs markdown.
+2) Local-link integrity gate: verifies local markdown links resolve.
+3) Canonical-tail gate: ensures canonical docs include required tail sections.
+
+Exit code is non-zero when any enabled check fails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_ROOT = REPO_ROOT / "docs"
+ROOT_README = REPO_ROOT / "README.md"
+
+GITHUB_ANNOTATION = "::error file={file},line={line},title={title}::{message}"
+
+TERMINOLOGY_PATTERNS = [
+    re.compile(r"\bMVP\b"),
+    re.compile(r"Post-MVP", re.IGNORECASE),
+]
+
+CANONICAL_DOCS = [
+    DOCS_ROOT / "PRD.md",
+    DOCS_ROOT / "scholarai" / "01_executive_summary.md",
+    DOCS_ROOT / "scholarai" / "02_prd_and_scope.md",
+    DOCS_ROOT / "scholarai" / "04_requirements_and_governance.md",
+]
+
+REQUIRED_CANONICAL_TAIL_SECTIONS = [
+    "## SLC decision (v0.1)",
+    "## Deferred By Stage",
+    "## Assumptions",
+    "## Risks",
+]
+
+
+def relpath(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT)).replace("\\", "/")
+
+
+def markdown_files() -> List[Path]:
+    files = [ROOT_README] if ROOT_README.exists() else []
+    files.extend(sorted(DOCS_ROOT.rglob("*.md")))
+    return files
+
+
+def find_terminology_failures(paths: Sequence[Path]) -> List[Tuple[Path, int, str]]:
+    failures: List[Tuple[Path, int, str]] = []
+    for path in paths:
+        content = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        for idx, line in enumerate(content, start=1):
+            for pattern in TERMINOLOGY_PATTERNS:
+                if pattern.search(line):
+                    failures.append((path, idx, line.strip()))
+                    break
+    return failures
+
+
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def iter_local_links(path: Path, content: str) -> Iterable[Tuple[int, str]]:
+    for idx, line in enumerate(content.splitlines(), start=1):
+        for m in LINK_RE.finditer(line):
+            link = m.group(1).strip()
+            if not link:
+                continue
+            if link.startswith(("http://", "https://", "mailto:", "#")):
+                continue
+            yield idx, link
+
+
+def resolve_link(current_file: Path, raw_link: str) -> Path:
+    link = raw_link.split("#", 1)[0].split("?", 1)[0].strip()
+    if re.match(r"^[A-Za-z]:[/\\]", link):
+        # Normalize Windows-style absolute path
+        return Path(link)
+    if link.startswith("/"):
+        return REPO_ROOT / link.lstrip("/")
+    return (current_file.parent / link).resolve()
+
+
+def find_broken_local_links(paths: Sequence[Path]) -> List[Tuple[Path, int, str]]:
+    failures: List[Tuple[Path, int, str]] = []
+    for path in paths:
+        content = path.read_text(encoding="utf-8", errors="replace")
+        for line_no, raw_link in iter_local_links(path, content):
+            target = resolve_link(path, raw_link)
+            if not target.exists():
+                failures.append((path, line_no, raw_link))
+    return failures
+
+
+def find_canonical_tail_failures(paths: Sequence[Path]) -> List[Tuple[Path, str]]:
+    failures: List[Tuple[Path, str]] = []
+    for path in paths:
+        if not path.exists():
+            failures.append((path, "Missing canonical file"))
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for required in REQUIRED_CANONICAL_TAIL_SECTIONS:
+            if required not in text:
+                failures.append((path, f"Missing section: {required}"))
+    return failures
+
+
+def print_error(file_path: Path, line: int, title: str, message: str) -> None:
+    print(
+        GITHUB_ANNOTATION.format(
+            file=relpath(file_path),
+            line=line,
+            title=title,
+            message=message.replace("%", "%25").replace("\n", "%0A"),
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run ScholarAI docs governance checks.")
+    parser.add_argument(
+        "--skip-canonical-tail",
+        action="store_true",
+        help="Skip canonical-tail section checks.",
+    )
+    args = parser.parse_args()
+
+    files = markdown_files()
+    failures = 0
+
+    terminology = find_terminology_failures(files)
+    if terminology:
+        failures += len(terminology)
+        for path, line_no, line in terminology:
+            print_error(path, line_no, "Terminology Gate", f"Blocked terminology: {line}")
+
+    broken_links = find_broken_local_links(files)
+    if broken_links:
+        failures += len(broken_links)
+        for path, line_no, raw_link in broken_links:
+            print_error(path, line_no, "Link Integrity", f"Broken local link: {raw_link}")
+
+    canonical_failures: List[Tuple[Path, str]] = []
+    if not args.skip_canonical_tail:
+        canonical_failures = find_canonical_tail_failures(CANONICAL_DOCS)
+        failures += len(canonical_failures)
+        for path, issue in canonical_failures:
+            print_error(path, 1, "Canonical Tail Gate", issue)
+
+    summary_lines = [
+        "Docs governance summary:",
+        f"- terminology failures: {len(terminology)}",
+        f"- broken links: {len(broken_links)}",
+        f"- canonical-tail failures: {len(canonical_failures)}",
+        f"- total failures: {failures}",
+    ]
+    print("\n".join(summary_lines))
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Stage Label (v0.1/v0.2/v0.3/v1.x)
`v0.1`

## SLC Decision Impact
Introduces a mandatory docs-governance quality gate in CI to enforce terminology consistency, link integrity, and canonical-tail section presence.

## Deferred By Stage Impact
Defers broad legacy-doc remediation to follow-up cleanups while landing enforcement mechanics and visibility now.

## UI Evidence (desktop + mobile or justified N/A)
N/A — CI/docs tooling only; no runtime UI change.

## Acceptance Criteria Mapping (checklist IDs)
- Supports governance readiness for acceptance evidence traceability consumed by v0.1 checklist artifacts.
- Enforces canonical SLC documentation structure required by governance docs.

## Risk / Rollback
Primary risk is merge blocking on pre-existing docs debt. Rollback is straightforward by reverting this PR commit to remove the gate.

## Scope
- `scripts/docs_governance_check.py`
- `.github/workflows/ci.yml`

## Validation Evidence
### Expected pass behavior
- `python scripts/docs_governance_check.py` exits 0 when:
  - No legacy terms (`MVP`, `Post-MVP`) in active scope (`README.md`, `docs/**/*.md`)
  - All local markdown links resolve
  - Canonical docs include: `SLC decision (v0.1)`, `Deferred By Stage`, `Assumptions`, `Risks`

### Expected failure behavior
- Inject temporary legacy term in active docs scope -> non-zero exit + terminology findings.
- Inject broken local markdown link -> non-zero exit + broken-link findings.
- Remove required canonical-tail section -> non-zero exit + canonical-tail findings.

### Current baseline note (important)
On current `origin/main`, local run reports existing pre-gate failures in docs (legacy terminology, broken links, and canonical-tail gaps). This PR intentionally introduces enforcement; docs cleanup can follow or be batched before requiring this gate in branch protection.
