### PR TITLE
test(governance): validate docs-governance branch protection enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,3 @@ ScholarAI implementation will follow a documentation-first path, with `docs/scho
 - Early code work before canonical docs are complete can lock in conflicting assumptions.
 
 
-Validation check injection: MVP


### PR DESCRIPTION
## Purpose
Validate branch protection enforcement for `docs-governance` on `main` by intentionally introducing a docs governance violation.

## What this PR does
- Adds a known failing legacy term (`MVP`) in `README.md`.
- Serves as a must-fail check for `docs-governance`.

## Expected behavior
- `docs-governance` should fail.
- Merge should be blocked if `docs-governance` is configured as a required check on `main`.

## Follow-up
A second commit will remove the violation to confirm must-pass behavior in the same PR.