### PR TITLE
fix(ci): enforce pipefail in docs-governance check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Run docs governance checks
         run: |
+          set -o pipefail
           python scripts/docs_governance_check.py | tee /tmp/docs-governance.out
 
       - name: Publish docs governance summary


### PR DESCRIPTION
## Summary
This follow-up permanently fixes a false-pass condition discovered during governance enforcement recheck (PR #46).

- Adds set -o pipefail before python scripts/docs_governance_check.py | tee ...
- Ensures the docs-governance job fails when the Python check emits an error

## Root Cause
Without pipefail, the step exit code was taken from 	ee (success) instead of the Python process (failure), allowing violations to pass.

## Validation
- Reproduced false-pass in PR #46 with intentional docs violation
- Confirmed fix causes must-fail behavior
- Confirmed must-pass behavior after violation removal

## Governance Contract
- .github/workflows/ci.yml remains source of truth
- Governance templates unchanged