### PR TITLE
chore(gitignore): ignore variant virtualenv and temp paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 *.egg
 venv/
 .venv/
+.venv*/
 env/
 
 # ML / Data
@@ -60,3 +61,4 @@ htmlcov/
 .pytest_cache/
 .mypy_cache/
 backend/runtime/
+.tmp/


### PR DESCRIPTION
## Why
Prevents accidental commits of generated env/temp files (e.g. `.venv312/`, `.tmp/`) that polluted PR #50.

## Changes
- add `.venv*/` to `.gitignore`
- add `.tmp/` to `.gitignore`

## Relationship to PR #50
Foundation hygiene PR that should merge first before other split PRs.