### PR TITLE
docs(claude.md): track S10 removal of browser-smoke continue-on-error flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ ScholarAI — AI scholarship platform. **Pakistan-pivot in progress (PRD `D:/Dow
 **Source of truth hierarchy:** PRD → `.codex/AGENTS.md` → `AGENTS.md` → `docs/scholarai/IMPLEMENTATION_STATUS_REPORT.md` → `docs/scholarai/01..14*.md` → this file. Legacy `docs/*.md` transitional.
 
 ## Stack
-Next.js 16 + React 19 + TS + Tailwind 4 (frontend). FastAPI + SQLAlchemy 2 async + Alembic + Celery + Redis + pgvector on Postgres 16 (backend). Docker Compose. CI: `.github/workflows/ci.yml` (backend-sanity, kpi-regression, frontend-sanity, docs-governance, browser-smoke).
+Next.js 16 + React 19 + TS + Tailwind 4 (frontend). FastAPI + SQLAlchemy 2 async + Alembic + Celery + Redis + pgvector on Postgres 16 (backend). Docker Compose. CI: `.github/workflows/ci.yml` (backend-sanity, kpi-regression, frontend-sanity, docs-governance, browser-smoke). CI `frontend-sanity` + `browser-smoke` run on Bun (`oven-sh/setup-bun@v2`, `bun install --frozen-lockfile`); the project has no `package-lock.json`.
 
 LLM = Anthropic Claude (`anthropic` SDK). Haiku 4.5 default; Sonnet 4.6 for SOP deep pass + Elite feedback. Prompt caching `cache_control: ephemeral` on static system prompts. Deterministic-template fallback when `ANTHROPIC_API_KEY` absent — CI + tests stay green offline.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ LLM = Anthropic Claude (`anthropic` SDK). Haiku 4.5 default; Sonnet 4.6 for SOP 
 ## Push gate (per AGENTS.md)
 All must pass before push: backend unit+integration, KPI regression, frontend lint/typecheck/build, docs governance, browser smoke. Smoke relaxed on greenfield branch until S10 / Frontend Pass.
 
+**CI temp flag (PR #84):** the `browser-smoke` step in `.github/workflows/ci.yml` carries `continue-on-error: true` because the greenfield rebuild left smoke `data-testid` selectors stale. The step still runs and logs, but a green `browser-smoke` job does NOT mean smoke passed — check the step log. **This flag must be removed during S10 / Frontend Pass, once smoke selectors are re-pointed to the rebuilt UI.**
+
 ## Demo accounts
 - student@example.com / strongpass1 (legacy seed)
 - admin@example.com / strongpass1
@@ -90,7 +92,7 @@ All must pass before push: backend unit+integration, KPI regression, frontend li
 3. Trace requirements → code → e2e before declaring feature done. Evidence > assertion.
 
 ## Open work
-- Frontend Pass: onboarding 4-step Pakistan → /scholarships/match → /tracker Kanban → SOP two-panel → visa interview UI → /upgrade pricing → UpgradeWall → Pakistan landing → consent UI + cookie banner + settings privacy → re-point smoke selectors.
+- Frontend Pass: onboarding 4-step Pakistan → /scholarships/match → /tracker Kanban → SOP two-panel → visa interview UI → /upgrade pricing → UpgradeWall → Pakistan landing → consent UI + cookie banner + settings privacy → re-point smoke selectors → **remove `continue-on-error: true` from the `browser-smoke` step in `.github/workflows/ci.yml`**.
 - ~~Apply migrations 0014–0018 against live dev DB and run seed orchestrator before manual smoke.~~ **Done 2026-05-12**: alembic at head `20260511_0018`; `demo_seed_pakistan.py` ran (20 PK scholarships, 30 universities, 70 visa Q, 5 legal docs, demo `zara.khan@example.com`).
 - Update `docs/scholarai/IMPLEMENTATION_STATUS_REPORT.md`, `frontend/README.md`, `.codex/AGENTS.md` to reflect Pakistan pivot.
 - Run KPI regression + docs governance to clear push gate.

--- a/progress.md
+++ b/progress.md
@@ -1,68 +1,56 @@
-# Progress — 2026-05-14
+# Progress — 2026-05-14 (session: PR #84 CI repair + test gap-fill)
 
-**Branch:** `feat/phase-c-and-scraper-wip` (pushed to origin)
-
-Branched off `feat/scraper-optimization` after Phase C re-verify on `feat/pakistan-pivot-merge`. Carries the Pakistan-pivot baseline plus four scraper-optimization PRs and the B2B Phase C handoff.
+**Branch:** `chore/document-smoke-flag-removal` (off `main` @ `7259c8b`; PR #86 open)
 
 ## Tasks completed this session
 
-### Phase C — B2B data-capture, frontend edit surface + snapshot expansion
-- `frontend/src/app/(student)/profile/page.tsx` (913 lines): 6-card rewrite — Contact / Academic / Tests / Goal / Aspirations / Background. Exposes all 25+ editable `StudentProfile` fields. `/api/v1/universities?country=<first target>` powers the shortlist picker. Optimistic save preserved. `bunx --bun tsc --noEmit` profile-clean (only pre-existing `EligibilityMatrix.tsx` drift remains, unrelated).
-- `backend/app/services/privacy/b2b_share.py::_profile_snapshot`: extended to surface every new B2B field at share time. DPA + `b2b_share_consent` enforcement unchanged.
-- `backend/tests/unit/test_privacy_and_b2b.py`: `_profile` SimpleNamespace fixture extended with all new snapshot fields. 14/14 tests green.
+### 1. Pakistan PRD test audit + gap-fill (earlier in session)
+- Audited `SCHOLARAI_PAKISTAN_PRD.md` (§0, §0.5, §0.6, §1–§10) against the backend test surface. Coverage already extensive; mapped every acceptance bullet to an existing suite.
+- Added `backend/tests/unit/test_b2b_trust_boundary.py` — AST-walks `app/services/recommendations` + `app/services/scholarships`, fails if they reference `Institution` / `InstitutionStudent` / `ReferralEnrollment` / `UniversityLead` or those table names. Enforces PRD §0.6 trust boundary in CI.
+- Added `backend/tests/unit/test_demo_seed_pakistan.py` — source-level pin on `scripts/demo_seed_pakistan.py` (zara persona, plan=elite, 2099 expiry, 5 consents, ≥10 scholarships / ≥30 unis / ≥70 visa Q). Runs offline, no DB.
+- Extended `_profile()` fixture in `tests/unit/test_privacy_and_b2b.py` with the migration-0019 B2B snapshot fields so the snapshot test is resilient to field additions.
+- Full backend suite green: **306 passed** (`pytest tests/unit tests/integration`).
+- This work shipped via PR #85 (`feat/phase-c-and-scraper-wip` → `main`, merged).
 
-### Scraper optimization PRs (chained on top of `feat/scraper-optimization`)
-- **`1bdde98` Conditional GET.** IngestionService stores per-source `ETag` / `Last-Modified`; subsequent fetches send `If-None-Match` / `If-Modified-Since`. `304 Not Modified` short-circuits — no parse, no LLM call, no DB write.
-- **`457b047` Sitemap + RSS/Atom feed discovery.** New `source_feed` table (migration `20260514_0020_ingestion_caching.py`). IngestionService now resolves robots.txt → sitemap-index → URLs and parses RSS/Atom feeds before falling back to full-page scrape. Only newer-than-`last_seen_at` entries get fetched.
-- **`fbdf473` DiscoveryService.** Crawl one level from a seed aggregator URL, keyword-filter outbound links, classify each candidate via Claude, return high-confidence `DiscoveredSource[]` for admin review. No auto-registration.
-- **`5db76fb`** export `DiscoveryService` from `app/services/ingestion/__init__.py`.
-- **`779490f` Tests + docs.** `test_ingestion_service` (ETag short-circuit + feed parsing), `test_discovery_service` (keyword filter + monkeypatched LLM classifier + confidence threshold), `test_b2b_trust_boundary` (PRD §0.6 enforcement: recommendation engine MUST NOT import from `university_leads` / `institutions`), `test_demo_seed_pakistan` (orchestrator coverage). Plus CLAUDE.md + this progress.md.
+### 2. PR #84 CI repair — all 4 failing checks fixed (merged)
+PR #84 (`feat/pakistan-pivot-merge` → `main`) had 4 red checks. Root causes + fixes:
+- **frontend-sanity + browser-smoke + Vercel** — CI used `actions/setup-node@v4` with `cache: npm` + `cache-dependency-path: frontend/package-lock.json`, but the greenfield rebuild migrated to Bun (`frontend/bun.lock`, no `package-lock.json`). Cache step aborted both jobs. Fix: `.github/workflows/ci.yml` migrated frontend jobs to `oven-sh/setup-bun@v2` + `bun install --frozen-lockfile` + `bun run lint/typecheck/build` + `bun run start`. Added missing `"typecheck": "tsc --noEmit"` script to `frontend/package.json`.
+- **docs-governance** — `scripts/docs_governance_check.py` flagged 3 broken local links in `docs/scholarai/PUBLIC_LIVE_HARDENING_PLAN.md` pointing at pre-rebuild frontend paths. Re-pointed: `auth-provider.tsx` → `lib/auth/AuthProvider.tsx`, `lib/api.ts` → `lib/api/client.ts`, `marketing-shell.tsx` → inlined-in-`app/page.tsx` note.
+- **Latent typecheck failure** — `bun run typecheck` (newly wired) surfaced 19 errors in `frontend/src/components/scholarship/EligibilityMatrix.tsx` reading pre-Pakistan-pivot `StudentProfile` fields. Re-pointed to canonical shape: `citizenship` → `citizenship_country_code`, `degree_level` → `target_degree_level`, `gpa` → `gpa_value`, `field_tags[]` → `target_field`, `language_scores[]` → `language_test_type` + `language_test_score`.
+- **browser-smoke still red after the above** — stale `data-testid` selectors from the greenfield rebuild (not real regressions). Added `continue-on-error: true` to the smoke step per the `AGENTS.md`/`CLAUDE.md` "smoke relaxed until S10 / Frontend Pass" doctrine.
+- Result: all 7 checks green. PR #84 **merged**.
+- Note: PR #84's branch was auto-deleted on merge; an accidental push recreated it as an orphan — deleted again (local + remote). Local safety tag `safety/c096dc8` left in place (harmless, local-only).
 
-### Housekeeping
-- `.gitignore`: `graphify-out/` (4.7M AST cache from the graphify skill) now excluded.
-- `CLAUDE.md`: appended scraper-pass note + Phase C done note. 116 lines, under the 200-line cap.
-- Earlier this session: branch confusion — `git checkout` mid-task from `feat/pakistan-pivot-merge` → `feat/scraper-optimization` made it look like edits had been reverted. They had only moved off the working tree. Re-verified Phase C work was already committed as `c096dc8` on `feat/pakistan-pivot-merge`.
-- Pushed `feat/phase-c-and-scraper-wip` to `origin`. PR URL: `https://github.com/HaiderNaqvi-5/scholarai-platform/pull/new/feat/phase-c-and-scraper-wip`.
+### 3. Document the temp CI flag (PR #86 — this branch)
+- `continue-on-error: true` on `browser-smoke` had no written removal trigger — risk of rotting into a permanent silent false-green.
+- `CLAUDE.md` edits:
+  - Stack line: notes CI `frontend-sanity` + `browser-smoke` run on Bun, no `package-lock.json`.
+  - Push gate section: documents the flag, warns a green `browser-smoke` job ≠ smoke passed, states the flag must be removed at S10 / Frontend Pass.
+  - Open work / Frontend Pass line: appends "remove `continue-on-error` from the `browser-smoke` step" to the existing "re-point smoke selectors" task.
+- CLAUDE.md at 118 lines (under 200 cap).
 
 ## Files touched this session
-- `backend/alembic/versions/20260514_0020_ingestion_caching.py` — new (source_feed table + ETag/Last-Modified columns on source_registry).
-- `backend/app/models/models.py` — `SourceFeed` ORM model + ETag/Last-Modified columns on `SourceRegistry`.
-- `backend/app/models/__init__.py` — export `SourceFeed`.
-- `backend/app/services/ingestion/__init__.py` — export `DiscoveryService`.
-- `backend/app/services/ingestion/service.py` — conditional-GET, sitemap parsing, feed parsing.
-- `backend/app/services/ingestion/discovery.py` — new module (233 lines).
-- `backend/app/services/privacy/b2b_share.py` — extended `_profile_snapshot` (already on `feat/pakistan-pivot-merge` HEAD as part of `c096dc8`).
-- `frontend/src/app/(student)/profile/page.tsx` — 6-card rewrite (same commit).
-- `backend/tests/unit/test_ingestion_service.py` — ETag + feed tests (257 lines).
-- `backend/tests/unit/test_discovery_service.py` — new (193 lines).
-- `backend/tests/unit/test_b2b_trust_boundary.py` — new (92 lines).
-- `backend/tests/unit/test_demo_seed_pakistan.py` — new (118 lines).
-- `backend/tests/unit/test_privacy_and_b2b.py` — fixture extension.
-- `.gitignore`, `CLAUDE.md`, `progress.md`.
+- `backend/tests/unit/test_b2b_trust_boundary.py` — new (PR #85).
+- `backend/tests/unit/test_demo_seed_pakistan.py` — new (PR #85).
+- `backend/tests/unit/test_privacy_and_b2b.py` — fixture extension (PR #85).
+- `.github/workflows/ci.yml` — Bun migration + `continue-on-error` on smoke (PR #84).
+- `frontend/package.json` — added `typecheck` script (PR #84).
+- `docs/scholarai/PUBLIC_LIVE_HARDENING_PLAN.md` — 3 broken links re-pointed (PR #84).
+- `frontend/src/components/scholarship/EligibilityMatrix.tsx` — canonical `StudentProfile` fields (PR #84).
+- `CLAUDE.md` — Bun-CI note + S10 flag-removal note (PR #86, this branch).
+- `progress.md` — this file.
 
 ## In-progress / next
-- Open PR on GitHub for `feat/phase-c-and-scraper-wip` if user wants review. URL above.
-- Apply migration `20260514_0020_ingestion_caching` against the live dev DB before exercising conditional GET / feed discovery end-to-end:
-  `docker exec scholarai-platform-backend-1 alembic upgrade head`.
-- Wire `/admin/sources` UI to surface `DiscoveryService` results for human approval. Currently the service is admin-callable but has no frontend route.
-- Pre-existing `frontend/src/components/scholarship/EligibilityMatrix.tsx` drift still blocks a fully-green typecheck (19 errors, all in that one file: uses `profile.citizenship` / `degree_level` / `gpa` / `field_tags` / `language_scores` — none on current `StudentProfile`). Out of scope this session.
-- Frontend container has no healthcheck (low priority; nothing depends on it).
-- `broker_connection_retry_on_startup=True` deprecation in `app/tasks/celery_app.py` — still deferred per the "no cosmetic" rule.
+- PR #86 open: `chore/document-smoke-flag-removal` → `main`. CLAUDE.md + progress.md only. Awaiting review/merge.
+- **S10 / Frontend Pass** must: re-point all smoke `data-testid` selectors AND remove `continue-on-error: true` from the `browser-smoke` step in `.github/workflows/ci.yml`.
+- Pre-existing low-priority items carried from prior sessions: `/admin/sources` UI for `DiscoveryService` results; apply migration `20260514_0020_ingestion_caching` to live dev DB; `broker_connection_retry_on_startup` deprecation in `app/tasks/celery_app.py`.
 
 ## Open bugs / blockers
-- None known. `/livez` 200; `/api/v1/universities` returns 30 rows for `country=GB` (401 without auth = correct).
+- None. PR #84 merged green; PR #86 is docs-only.
 
 ## Commands to resume
-- Stack: `cd scholarai-platform && docker compose up -d`
-- Migrations: `docker exec scholarai-platform-backend-1 alembic upgrade head`
-- Frontend dev: `cd scholarai-platform/frontend && bun dev` (port 3001)
-- Backend reload after a code change: `docker cp <path> scholarai-platform-backend-1:/app/<same-path> && docker restart scholarai-platform-backend-1`
-- Health: `curl http://localhost:8000/livez && curl http://localhost:8000/readyz`
-- Tests:
-  - `docker exec scholarai-platform-backend-1 pytest tests/unit/test_privacy_and_b2b.py -q`
-  - `docker exec scholarai-platform-backend-1 pytest tests/unit/test_ingestion_service.py -q`
-  - `docker exec scholarai-platform-backend-1 pytest tests/unit/test_discovery_service.py -q`
-  - `docker exec scholarai-platform-backend-1 pytest tests/unit/test_b2b_trust_boundary.py -q`
-  - `docker exec scholarai-platform-backend-1 pytest tests/unit/test_demo_seed_pakistan.py -q`
-- Typecheck: `cd scholarai-platform/frontend && bunx --bun tsc --noEmit`
-- Push gate (per `AGENTS.md`): backend unit+integration, KPI regression, frontend lint/typecheck/build, docs governance, browser smoke.
+- Backend tests: `cd backend && python -m pytest tests/unit tests/integration -q`
+- Frontend gate: `cd frontend && bun install --frozen-lockfile && bun run lint && bun run typecheck && bun run build`
+- Docs gate: `python scripts/docs_governance_check.py`
+- API: `cd backend && python -m uvicorn app.main:app --reload`
+- Frontend dev: `cd frontend && bun dev`


### PR DESCRIPTION
## Why

PR #84 added `continue-on-error: true` to the `browser-smoke` step in `.github/workflows/ci.yml` as a temporary bridge — the greenfield frontend rebuild left smoke `data-testid` selectors stale, so the step fails on selectors rather than real regressions.

That flag is **temporary**, but nothing in `CLAUDE.md` named the removal trigger. Risk: it rots into a permanent silent false-green, and a real regression later hides behind it.

## Change

Docs only — `CLAUDE.md` + `progress.md`:

**CLAUDE.md**
1. Stack line — note CI `frontend-sanity` + `browser-smoke` run on Bun (`oven-sh/setup-bun@v2`), project has no `package-lock.json`.
2. Push gate section — documents the flag, warns that a green `browser-smoke` job does not mean smoke passed (check the step log), states the flag must be removed at S10 / Frontend Pass.
3. Open work / Frontend Pass line — appends "remove `continue-on-error` from the `browser-smoke` step" to the existing "re-point smoke selectors" task.

**progress.md** — session handoff refresh: Pakistan PRD test gap-fill, PR #84 CI repair, and this doc note. Records the S10 cleanup obligation.

No code or workflow changes. CLAUDE.md at 119 lines (under the 200-line cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)