### PR TITLE
fix(backend): use mcr Playwright base image — DO build OOM fix

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,22 +1,25 @@
 # Stage 1: Builder
-FROM python:3.11-slim AS builder
+# Microsoft's Playwright Python image ships with Chromium + all OS deps pre-installed
+# at /ms-playwright. Avoids the `playwright install --with-deps chromium` step that
+# OOM'd DO's App Platform builder. Scraper Celery worker launches Chromium at runtime
+# exactly as before.
+FROM mcr.microsoft.com/playwright/python:v1.52.0-jammy AS builder
 
 WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
+# jammy base has python3 + build-essential + gcc; only need libpq-dev for asyncpg/psycopg2.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
     libpq-dev \
-    gcc \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
 RUN pip wheel --no-cache-dir --no-deps --wheel-dir /app/wheels -r requirements.txt
 
 # Stage 2: Runtime
-FROM python:3.11-slim
+FROM mcr.microsoft.com/playwright/python:v1.52.0-jammy
 
 WORKDIR /app
 
@@ -30,25 +33,22 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --default-timeout=600 --retries 10 \
     --find-links=/wheels -r requirements.txt
 
-# Install Chromium + its OS deps for the scraper Celery worker (Playwright).
-# Lives in a fixed path so the non-root appuser can read the binary after
-# the chown below; PLAYWRIGHT_BROWSERS_PATH is also exported to runtime so
-# Python's playwright SDK finds the same install.
-ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
-RUN python -m playwright install --with-deps chromium
+# Chromium lives at /ms-playwright in the Microsoft base image. Export the path
+# so the Python playwright SDK locates it at runtime.
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 COPY . .
 
-# Security: Run as non-root user (chown the Playwright cache too so the
-# scraper worker can launch Chromium without permission errors).
+# Run as non-root. /ms-playwright is world-readable in the base image so no chown
+# needed there.
 RUN adduser --disabled-password --gecos "" appuser \
-    && chown -R appuser /app /opt/playwright-browsers
+    && chown -R appuser /app
 USER appuser
 
 EXPOSE 8000
 
 # Image is process-agnostic (same image runs uvicorn, celery worker, celery beat).
-# Healthchecks live at the orchestration layer (docker-compose.yml / k8s manifests),
-# not baked into the image. Each service defines a check appropriate to its process.
+# Healthchecks live at the orchestration layer (DO app spec / docker-compose.yml),
+# not baked into the image. Each component declares a check appropriate to its process.
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- DO App Platform builder OOM'd on `playwright install --with-deps chromium` (chromium download ~700MB → `BuildJobTerminated`)
- Switch both Dockerfile stages to `mcr.microsoft.com/playwright/python:v1.52.0-jammy` — Microsoft's official Playwright Python image with Chromium + all OS deps pre-installed at `/ms-playwright`
- Scraper Celery worker keeps working: same Chromium revision (pinned to SDK 1.52.0), same selectors, same fingerprint
- Build skips the chromium download → fits DO's build cap

## Test plan
- [ ] CI green (backend-sanity, kpi-regression, frontend-sanity, docs-governance, browser-smoke)
- [ ] Post-merge: `doctl apps create-deployment 545232cd-ae30-496e-92c4-b6e173eb7631` succeeds end-to-end (web + alembic-migrate + celery-worker + celery-beat all SUCCESS)
- [ ] Smoke `curl https://<default-url>/livez` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)