### PR TITLE
chore(frontend): branded favicon — Fraunces-italic A in lapis on ivory

### DIFF
--- a/frontend/src/app/icon.svg
+++ b/frontend/src/app/icon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="AidwiseAI">
+  <style>
+    .bg { fill: #FBF7EE; }
+    .glyph { fill: #1B3A6B; }
+    .jewel { fill: #B08A3E; }
+    @media (prefers-color-scheme: dark) {
+      .bg { fill: #0E1A1F; }
+      .glyph { fill: #FBF7EE; }
+      .jewel { fill: #B08A3E; }
+    }
+  </style>
+  <rect class="bg" width="32" height="32" rx="7" />
+  <text
+    class="glyph"
+    x="15.5"
+    y="23.5"
+    text-anchor="middle"
+    font-family="'Fraunces','Playfair Display',Georgia,'Times New Roman',serif"
+    font-style="italic"
+    font-weight="600"
+    font-size="22"
+    letter-spacing="-0.5"
+  >A</text>
+  <circle class="jewel" cx="23.5" cy="9" r="1.9" />
+</svg>


### PR DESCRIPTION
## Summary
- Adds `frontend/src/app/icon.svg` — branded AidwiseAI mark (Fraunces-italic "A" in lapis `#1B3A6B` on ivory `#FBF7EE` rounded square, gold-leaf `#B08A3E` jewel-dot accent).
- Honors `prefers-color-scheme: dark` (ink-deep bg + ivory glyph swap).
- Next.js 16 metadata convention auto-wires `<link rel="icon">` from `app/icon.svg`; legacy `favicon.ico` retained as fallback for older browsers.
- One-accent-per-surface rule respected; sindoor reserved for danger-only.

## Test plan
- [x] `bun run build` green — `/icon.svg` registered as static route
- [ ] Visual check at 16px / 32px / 180px in browser tab + bookmark bar
- [ ] Dark-mode swap verifies in OS-level dark setting
- [ ] No regression in `bun run lint` / `bunx --bun tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)