### PR TITLE
fix(backend): single-stage Dockerfile + binary-preferred wheels (DO OOM v2)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,46 +1,41 @@
-# Stage 1: Builder
-# Microsoft's Playwright Python image ships with Chromium + all OS deps pre-installed
-# at /ms-playwright. Avoids the `playwright install --with-deps chromium` step that
-# OOM'd DO's App Platform builder. Scraper Celery worker launches Chromium at runtime
-# exactly as before.
-FROM mcr.microsoft.com/playwright/python:v1.52.0-jammy AS builder
-
-WORKDIR /app
-
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
-
-# jammy base has python3 + build-essential + gcc; only need libpq-dev for asyncpg/psycopg2.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libpq-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY requirements.txt .
-RUN pip wheel --no-cache-dir --no-deps --wheel-dir /app/wheels -r requirements.txt
-
-# Stage 2: Runtime
+# Single-stage Dockerfile.
+# DO App Platform's builder OOM'd on the prior 2-stage variant because
+# `pip wheel ... --wheel-dir /app/wheels` cached ~2GB of compiled wheels
+# (torch via sentence-transformers, lxml, shap, xgboost, pandas) and then
+# stage 2 reinstalled them — doubling disk pressure past the builder cap.
+# Single-stage skips the wheel-cache duplication.
+#
+# Microsoft's Playwright Python image ships Chromium + all OS deps
+# pre-installed at /ms-playwright pinned to the exact revision Playwright
+# SDK 1.52.0 expects. Scraper Celery worker launches Chromium at runtime
+# unchanged.
 FROM mcr.microsoft.com/playwright/python:v1.52.0-jammy
 
 WORKDIR /app
 
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_PREFER_BINARY=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# Only libpq-dev for asyncpg/psycopg2; jammy base has gcc/build-essential already.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /app/wheels /wheels
+# Install deps first for layer cache (changes less than source).
 COPY requirements.txt .
 RUN pip install --no-cache-dir --default-timeout=600 --retries 10 \
-    --find-links=/wheels -r requirements.txt
-
-# Chromium lives at /ms-playwright in the Microsoft base image. Export the path
-# so the Python playwright SDK locates it at runtime.
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+    --only-binary=:all: -r requirements.txt \
+    || pip install --no-cache-dir --default-timeout=600 --retries 10 \
+       -r requirements.txt
 
 COPY . .
 
-# Run as non-root. /ms-playwright is world-readable in the base image so no chown
-# needed there.
+# Run as non-root.
 RUN adduser --disabled-password --gecos "" appuser \
     && chown -R appuser /app
 USER appuser
@@ -48,7 +43,6 @@ USER appuser
 EXPOSE 8000
 
 # Image is process-agnostic (same image runs uvicorn, celery worker, celery beat).
-# Healthchecks live at the orchestration layer (DO app spec / docker-compose.yml),
-# not baked into the image. Each component declares a check appropriate to its process.
+# Healthchecks live at the orchestration layer (DO app spec / docker-compose.yml).
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/frontend/src/app/icon.svg
+++ b/frontend/src/app/icon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="AidwiseAI">
+  <style>
+    .bg { fill: #FBF7EE; }
+    .glyph { fill: #1B3A6B; }
+    .jewel { fill: #B08A3E; }
+    @media (prefers-color-scheme: dark) {
+      .bg { fill: #0E1A1F; }
+      .glyph { fill: #FBF7EE; }
+      .jewel { fill: #B08A3E; }
+    }
+  </style>
+  <rect class="bg" width="32" height="32" rx="7" />
+  <text
+    class="glyph"
+    x="15.5"
+    y="23.5"
+    text-anchor="middle"
+    font-family="'Fraunces','Playfair Display',Georgia,'Times New Roman',serif"
+    font-style="italic"
+    font-weight="600"
+    font-size="22"
+    letter-spacing="-0.5"
+  >A</text>
+  <circle class="jewel" cx="23.5" cy="9" r="1.9" />
+</svg>


### PR DESCRIPTION
## Summary
- Prior 2-stage Dockerfile (PR #95) still OOM'd DO's builder because `pip wheel` cached ~2GB of wheels in `/app/wheels` and stage 2 reinstalled them — doubling disk pressure
- Switch to single-stage with `--only-binary=:all:` (manylinux wheels, no in-image compile) + `PIP_PREFER_BINARY=1`
- Heavy deps (torch via sentence-transformers, lxml, shap, xgboost, pandas) all have manylinux wheels on PyPI — no compile needed
- Source-build fallback retained for any package without a published wheel

## Test plan
- [ ] CI green
- [ ] Post-merge: `doctl apps create-deployment <existing-APP-ID>` succeeds (build under DO cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)