### PR TITLE
fix(deploy): switch app spec from GitHub source to DOCR image

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -3,12 +3,12 @@ region: blr
 
 services:
   - name: web
-    github:
-      repo: HaiderNaqvi-5/scholarai-platform
-      branch: main
-      deploy_on_push: true
-    source_dir: backend
-    dockerfile_path: backend/Dockerfile
+    image:
+      registry_type: DOCR
+      repository: backend
+      tag: v1
+      deploy_on_push:
+        enabled: true
     instance_size_slug: basic-xxs
     instance_count: 1
     http_port: 8000
@@ -115,12 +115,12 @@ services:
 
 workers:
   - name: celery-worker
-    github:
-      repo: HaiderNaqvi-5/scholarai-platform
-      branch: main
-      deploy_on_push: true
-    source_dir: backend
-    dockerfile_path: backend/Dockerfile
+    image:
+      registry_type: DOCR
+      repository: backend
+      tag: v1
+      deploy_on_push:
+        enabled: true
     instance_size_slug: basic-xxs
     instance_count: 1
     run_command: celery -A app.tasks.celery_app:celery_app worker -l info --concurrency 2
@@ -158,12 +158,12 @@ workers:
         type: SECRET
 
   - name: celery-beat
-    github:
-      repo: HaiderNaqvi-5/scholarai-platform
-      branch: main
-      deploy_on_push: true
-    source_dir: backend
-    dockerfile_path: backend/Dockerfile
+    image:
+      registry_type: DOCR
+      repository: backend
+      tag: v1
+      deploy_on_push:
+        enabled: true
     instance_size_slug: basic-xxs
     instance_count: 1
     run_command: celery -A app.tasks.celery_app:celery_app beat -l info
@@ -191,11 +191,10 @@ workers:
 jobs:
   - name: alembic-migrate
     kind: PRE_DEPLOY
-    github:
-      repo: HaiderNaqvi-5/scholarai-platform
-      branch: main
-    source_dir: backend
-    dockerfile_path: backend/Dockerfile
+    image:
+      registry_type: DOCR
+      repository: backend
+      tag: v1
     instance_size_slug: basic-xxs
     instance_count: 1
     run_command: alembic upgrade head


### PR DESCRIPTION
## Summary
- DO App Platform builder consistently OOMs on the Python dep tree (torch + ML stack ~3GB) regardless of Dockerfile tuning (PRs #95, #97 both still failed)
- Bypass DO's builder entirely: build image locally on dev machine where resources are unlimited, push to DOCR, point spec at registry image
- Spec swaps every `github:` source block for `image: { registry_type: DOCR, repository: backend, tag: v1 }`
- Drops `source_dir` + `dockerfile_path` (no build step on DO anymore)

## Test plan
- [ ] CI green
- [ ] Post-merge: `doctl apps update bb57decf-3324-4fa8-935c-409a355dac43 --spec .do/app.yaml`
- [ ] Web + worker + beat + alembic-migrate all pull image and start (no build phase to OOM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)